### PR TITLE
Allow underscores in model identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class Replicate {
    */
   async run(identifier, options) {
     const pattern =
-      /^(?<owner>[a-zA-Z0-9-]+?)\/(?<name>[a-zA-Z0-9-]+?):(?<version>[0-9a-fA-F]+)$/;
+      /^(?<owner>[a-zA-Z0-9-_]+?)\/(?<name>[a-zA-Z0-9-_]+?):(?<version>[0-9a-fA-F]+)$/;
     const match = identifier.match(pattern);
 
     if (!match) {


### PR DESCRIPTION
Hi! pretty certain this is how the regex should be set up - I'm trying to run "tommoore515/material_stable_diffusion:3b5c0242f8925a4ab6c79b4c51e9b4ce6374e9b07b5e8461d89e692fd0faa449" and getting errors

Thanks for the library - much nicer than raw fetches :) 