### PR TITLE
feat: add webhook and webhook_events_filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,12 @@ const response = await replicate.collections.get(collection_slug);
 const response = await replicate.predictions.create(options);
 ```
 
-| name                        | type   | description                                                               |
-| --------------------------- | ------ | ------------------------------------------------------------------------- |
-| `options.version`           | string | **Required**. The model version                                           |
-| `options.input`             | object | **Required**. An object with the models inputs                            |
-| `options.webhook_completed` | string | A URL which will receive a POST request upon completion of the prediction |
+| name                            | type     | description                                                                                                                      |
+| ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `options.version`               | string   | **Required**. The model version                                                                                                  |
+| `options.input`                 | object   | **Required**. An object with the models inputs                                                                                   |
+| `options.webhook`               | string   | An HTTPS URL for receiving a webhook when the prediction has new output                                                          |
+| `options.webhook_events_filter` | string[] | You can change which events trigger webhook requests by specifying webhook events (`start` \| `output` \| `logs` \| `completed`) |
 
 ```jsonc
 {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 type Identifier = `${string}/${string}:${string}`;
+type WebhookEventType = "start" | "output" | "logs" | "completed";
 
 declare module "replicate" {
   export interface ReplicateOptions {
@@ -36,7 +37,8 @@ declare module "replicate" {
     version: string;
     input: any;
     output: any;
-    webhook_completed: string;
+    webhook?: string;
+    webhook_events_filter?: WebhookEventType[];
     created: string;
     updated: string;
   }
@@ -64,7 +66,8 @@ declare module "replicate" {
   export interface PredictionsCreateOptions {
     version: string;
     input: any;
-    webhook_completed?: string;
+    webhook?: string;
+    webhook_events_filter?: WebhookEventType[];
   }
 
   export interface PredictionsGetOptions {
@@ -79,7 +82,8 @@ declare module "replicate" {
       options: {
         input: object;
         wait?: boolean | { interval?: number; maxAttempts?: number };
-        webhook_completed?: string;
+        webhook?: string;
+        webhook_events_filter?: WebhookEventType[];
       }
     ): Promise<object>;
     request(route: string, parameters: any): Promise<any>;

--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ class Replicate {
    * @param {boolean|object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
    * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
    * @param {number} [options.wait.maxAttempts] - Maximum number of polling attempts. Defaults to no limit
-   * @param {string} [options.webhook_completed] - A URL which will receive a POST request upon completion of the prediction
+   * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
+   * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
    * @throws {Error} If the prediction failed
    * @returns {Promise<object>} - Resolves with the output of running the model
    */

--- a/index.test.js
+++ b/index.test.js
@@ -60,6 +60,30 @@ describe('Replicate client', () => {
       });
     });
 
+    test('Calls the correct API route with the correct payload, webhook URL and webhook filters', async () => {
+      client.request = jest.fn();
+      const input = { text: 'Hello, world!' };
+      await client.predictions.create({
+        version:
+          '632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532',
+        input,
+        webhook: 'http://test.host/webhook',
+        webhook_events_filter: ['output', 'completed'],
+      });
+      expect(client.request).toHaveBeenCalledWith('/predictions', {
+        method: 'POST',
+        data: {
+          version:
+            '632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532',
+          input: {
+            text: 'Hello, world!',
+          },
+          webhook: 'http://test.host/webhook',
+          webhook_events_filter: ['output', 'completed'],
+        },
+      });
+    });
+
     // Add more tests for error handling, edge cases, etc.
   });
 

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -7,7 +7,8 @@
  * @param {boolean|object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
  * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
  * @param {number} [options.wait.maxAttempts] - Maximum number of polling attempts. Defaults to no limit
- * @param {string} [options.webhook_completed] - A URL which will receive a POST request upon completion of the prediction
+ * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
+ * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
  * @returns {Promise<object>} Resolves with the created prediction data
  */
 async function createPrediction(options) {


### PR DESCRIPTION
Consistency with official docs:
- Docs: https://replicate.com/docs/reference/http#predictions.create--webhook_events_filter
- Model API (`Node.js`): https://replicate.com/stability-ai/stable-diffusion/api