### PR TITLE
Configure `jsconfig.json` and `tsconfig.json`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   overrides: [],
   parserOptions: {
     ecmaVersion: 'latest',
-    project: './tsconfig.json',
+    project: './jsconfig.json',
   },
   plugins: ['jest', 'jsdoc'],
   rules: {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ class Replicate {
       /^(?<owner>[a-zA-Z0-9-_]+?)\/(?<name>[a-zA-Z0-9-_]+?):(?<version>[0-9a-fA-F]+)$/;
     const match = identifier.match(pattern);
 
-    if (!match) {
+    if (!match || !match.groups) {
       throw new Error(
         'Invalid version. It must be in the format "owner/name:version"'
       );

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class Replicate {
    * @param {string} identifier - Required. The model version identifier in the format "{owner}/{name}:{version}"
    * @param {object} options
    * @param {object} options.input - Required. An object with the model inputs
-   * @param {boolean|object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
+   * @param {object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
    * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
    * @param {number} [options.wait.maxAttempts] - Maximum number of polling attempts. Defaults to no limit
    * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts?$': ['ts-jest', {
+      tsconfig: 'tsconfig.json'
+    }],
+  },
 };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "checkJs": true,
+        "module": "ESNext",
+        "moduleResolution": "Node",
+        "target": "ES2020",
+        "resolveJsonModule": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true
+    },
+    "exclude": [
+        "node_modules",
+        "**/node_modules/*"
+    ]
+}

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -20,7 +20,7 @@ async function createPrediction(options) {
   });
 
   if (wait) {
-    const { maxAttempts, interval } = options.wait;
+    const { maxAttempts, interval } = wait;
     return this.wait(await prediction, { maxAttempts, interval });
   }
 

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -4,7 +4,7 @@
  * @param {object} options
  * @param {string} options.version - Required. The model version
  * @param {object} options.input - Required. An object with the model inputs
- * @param {boolean|object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
+ * @param {object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
  * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
  * @param {number} [options.wait.maxAttempts] - Maximum number of polling attempts. Defaults to no limit
  * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.9.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@tsconfig/recommended": "^1.0.2",
         "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "cross-fetch": "^3.1.5",
@@ -1233,12 +1232,6 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
-    },
-    "node_modules/@tsconfig/recommended": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.2.tgz",
-      "integrity": "sha512-dbHBtbWBOjq0/otpopAE02NT2Cm05Qe2JsEKeCf/wjSYbI2hz8nCqnpnOJWHATgjDz4fd3dchs3Wy1gQGjfN6w==",
-      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@tsconfig/recommended": "^1.0.2",
     "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "cross-fetch": "^3.1.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@tsconfig/recommended/tsconfig.json"
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+      "esModuleInterop": true
+  },
+  "exclude": [
+      "node_modules",
+      "**/node_modules/*"
+  ]
+}


### PR DESCRIPTION
This PR enables type checking in JavaScript files and TypeScript files. It also fixes the errors surfaced by type checking.