### PR TITLE
Update identifier validation logic for `run` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,10 +80,18 @@ class Replicate {
    * @returns {Promise<object>} - Resolves with the output of running the model
    */
   async run(identifier, options) {
-    const pattern =
-      /^(?<owner>[a-zA-Z0-9-_]+?)\/(?<name>[a-zA-Z0-9-_]+?):(?<version>[0-9a-fA-F]+)$/;
-    const match = identifier.match(pattern);
+    // Define a pattern for owner and model names that allows
+    // letters, digits, and certain special characters.
+    // Example: "user123", "abc__123", "user.name"
+    const namePattern = /[a-zA-Z0-9]+(?:(?:[._]|__|[-]*)[a-zA-Z0-9]+)*/;
 
+    // Define a pattern for "owner/name:version" format with named capturing groups.
+    // Example: "user123/repo_a:1a2b3c"
+    const pattern = new RegExp(
+      `^(?<owner>${namePattern.source})/(?<name>${namePattern.source}):(?<version>[0-9a-fA-F]+)$`
+    );
+
+    const match = identifier.match(pattern);
     if (!match || !match.groups) {
       throw new Error(
         'Invalid version. It must be in the format "owner/name:version"'

--- a/index.test.ts
+++ b/index.test.ts
@@ -392,6 +392,23 @@ describe('Replicate client', () => {
       expect(output).toBe('foobar');
     });
 
+    test('Does not throw an error for identifier containing hyphen and full stop', async () => {
+      nock(BASE_URL)
+        .post('/predictions')
+        .reply(200, {
+          id: 'ufawqhfynnddngldkgtslldrkq',
+          status: 'processing',
+        })
+        .get('/predictions/ufawqhfynnddngldkgtslldrkq')
+        .reply(200, {
+          id: 'ufawqhfynnddngldkgtslldrkq',
+          status: 'succeeded',
+          output: 'foobar',
+        });
+
+      await expect(client.run('a/b-1.0:abc123', { input: { text: 'Hello, world!' } })).resolves.not.toThrow();
+    });
+
     test('Throws an error for invalid identifiers', async () => {
       const options = { input: { text: 'Hello, world!' } }
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -391,6 +391,20 @@ describe('Replicate client', () => {
       );
       expect(output).toBe('foobar');
     });
+
+    test('Throws an error for invalid identifiers', async () => {
+      const options = { input: { text: 'Hello, world!' } }
+
+      await expect(client.run('owner/model:invalid', options)).rejects.toThrow();
+
+      // @ts-expect-error
+      await expect(client.run('owner:abc123', options)).rejects.toThrow();
+
+      await expect(client.run('/model:abc123', options)).rejects.toThrow();
+
+      // @ts-expect-error
+      await expect(client.run(':abc123', options)).rejects.toThrow();
+    });
   });
 
   // Continue with tests for other methods


### PR DESCRIPTION
Replicate validates owner and model names using the naming rules for [Docker images](https://docs.docker.com/engine/reference/commandline/tag/#description). 

The current regex pattern used to validate identifiers passed to `run` doesn't account for hyphens (`-`) or full stops (`.`), and incorrectly throws an error for valid identifiers like `cjwbw/anything-v4.0:42a996d39a96aedc57b2e0aa8105dea39c9c89d9d266caf6bb4327a1c191b061`.

This PR updates the regex pattern to be in line with Replicate naming rules, and adds test coverage to ensure correct behavior.