### PR TITLE
Add `fetch` to type definition for constructor options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ declare module 'replicate' {
       auth: string;
       userAgent?: string;
       baseUrl?: string;
+      fetch?: Function;
     });
 
     auth: string;


### PR DESCRIPTION
Related to #69

There's a TypeScript type definition for the `fetch` property on `Client`, but not the constructor option. This PR adds that.