### PR TITLE
Fix JSDoc linting issues

### DIFF
--- a/lib/collections.js
+++ b/lib/collections.js
@@ -12,6 +12,7 @@ async function getCollection(collection_slug) {
 
 /**
  * Fetch a list of model collections
+ *
  * @returns {Promise<object>} - Resolves with the collections data
  */
 async function listCollections() {

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -4,7 +4,7 @@
  * @param {object} options
  * @param {string} options.version - Required. The model version
  * @param {object} options.input - Required. An object with the model inputs
- * @param {object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
+ * @param {boolean|object} [options.wait] - Whether to wait for the prediction to finish. Defaults to false
  * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
  * @param {number} [options.wait.maxAttempts] - Maximum number of polling attempts. Defaults to no limit
  * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output


### PR DESCRIPTION
This PR addresses two small documentation issues:

1. The `wait` parameter in `predictions.create` can be either `boolean` or an `object`.
2. The documentation from `collections.list` is missing a newline before parameters. 