### PR TITLE
Throw error when constructing `Client` without required `auth` parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ class Replicate {
    * @param {Function} [options.fetch] - Fetch function to use. Defaults to `globalThis.fetch`
    */
   constructor(options) {
+    if (!options.auth) {
+      throw new Error('Missing required parameter: auth');
+    }
+
     this.auth = options.auth;
     this.userAgent =
       options.userAgent || `replicate-javascript/${packageJSON.version}`;

--- a/index.test.ts
+++ b/index.test.ts
@@ -33,6 +33,22 @@ describe('Replicate client', () => {
       });
       expect(clientWithCustomUserAgent.userAgent).toBe('my-app/1.2.3');
     });
+
+    test('Throws error if no auth token is provided', () => {
+      const expected = 'Missing required parameter: auth'
+
+      expect(() => {
+        new Replicate({ auth: undefined });
+      }).toThrow(expected);
+
+      expect(() => {
+        new Replicate({ auth: null });
+      }).toThrow(expected);
+
+      expect(() => {
+        new Replicate({ auth: "" });
+      }).toThrow(expected);
+    });
   });
 
   describe('collections.list', () => {


### PR DESCRIPTION
Fixes #76

This PR throws if the `auth` parameter passed to `new Client({ ... })` is missing. Specifically, this PR uses an `if (!options.auth)` conditional, which is satisfied by falsy values including `null`, `undefined`, and `""`.