### PR TITLE
Sleep after creating a prediction before polling for updates

### DIFF
--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -21,6 +21,11 @@ async function createPrediction(options) {
 
   if (wait) {
     const { maxAttempts, interval } = wait;
+
+    // eslint-disable-next-line no-promise-executor-return
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    await sleep(interval || 250);
+
     return this.wait(await prediction, { maxAttempts, interval });
   }
 


### PR DESCRIPTION
The `predictions.create` function can pass a `wait` option to poll for changes automatically. Currently, the first `predictions.get` request to query the status of the prediction happens immediately after the initial response, before the prediction is likely to be processed. This PR introduces an initial delay of the configured wait interval (250ms by default).