### PR TITLE
Add `engines.node` entry to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bugs": "https://github.com/replicate/replicate-javascript/issues",
   "license": "Apache-2.0",
   "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "jest"


### PR DESCRIPTION
Required by `np` v8.0.2 for publishing new versions.