### PR TITLE
Update usage documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,14 @@ const response = await replicate.predictions.list();
 ### `replicate.trainings.create`
 
 ```js
-const response = await replicate.trainings.create(options);
+const response = await replicate.trainings.create(model_owner, model_name, version_id, options);
 ```
 
 | name                            | type     | description                                                                                                                      |
 | ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `options.version`               | string   | **Required**. The model version                                                                                                  |
+| `model_owner`                   | string   | **Required**. The name of the user or organization that owns the model.                                                          |
+| `model_name`                    | string   | **Required**. The name of the model.                                                                                             |
+| `version`                       | string   | **Required**. The model version                                                                                                  |
 | `options.destination`           | string   | **Required**. The destination for the trained version in the form `{username}/{model_name}`                                      |
 | `options.input`                 | object   | **Required**. An object with the model's inputs                                                                                  |
 | `options.webhook`               | string   | An HTTPS URL for receiving a webhook when the training has new output                                                            |

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ const response = await replicate.trainings.create(model_owner, model_name, versi
 ```jsonc
 {
   "id": "zz4ibbonubfz7carwiefibzgga",
-  "version": "{version}",
+  "version": "3ae0799123a1fe11f8c89fd99632f843fc5f7a761630160521c4253149754523",
   "status": "starting",
   "input": {
     "text": "..."
@@ -371,7 +371,7 @@ const response = await replicate.trainings.get(training_id);
 ```jsonc
 {
   "id": "zz4ibbonubfz7carwiefibzgga",
-  "version": "{version}",
+  "version": "3ae0799123a1fe11f8c89fd99632f843fc5f7a761630160521c4253149754523",
   "status": "succeeded",
   "input": {
     "data": "..."
@@ -402,7 +402,7 @@ const response = await replicate.trainings.cancel(training_id);
 ```jsonc
 {
   "id": "zz4ibbonubfz7carwiefibzgga",
-  "version": "{version}",
+  "version": "3ae0799123a1fe11f8c89fd99632f843fc5f7a761630160521c4253149754523",
   "status": "canceled",
   "input": {
     "data": "..."

--- a/README.md
+++ b/README.md
@@ -294,6 +294,38 @@ const response = await replicate.predictions.get(prediction_id);
 }
 ```
 
+### `replicate.predictions.cancel`
+
+```js
+const response = await replicate.predictions.cancel(prediction_id);
+```
+
+| name            | type   | description                     |
+| --------------- | ------ | ------------------------------- |
+| `prediction_id` | number | **Required**. The prediction id |
+
+```jsonc
+{
+  "id": "ufawqhfynnddngldkgtslldrkq",
+  "version": "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+  "urls": {
+    "get": "https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq",
+    "cancel": "https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel"
+  },
+  "created_at": "2022-04-26T22:13:06.224088Z",
+  "started_at": "2022-04-26T22:13:06.224088Z",
+  "completed_at": "2022-04-26T22:13:06.224088Z",
+  "status": "canceled",
+  "input": {
+    "text": "Alice"
+  },
+  "output": null,
+  "error": null,
+  "logs": null,
+  "metrics": {}
+}
+```
+
 ### `replicate.predictions.list`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -389,6 +389,37 @@ const response = await replicate.trainings.get(training_id);
 }
 ```
 
+### `replicate.trainings.cancel`
+
+```js
+const response = await replicate.trainings.cancel(training_id);
+```
+
+| name          | type   | description                   |
+| ------------- | ------ | ----------------------------- |
+| `training_id` | number | **Required**. The training id |
+
+```jsonc
+{
+  "id": "zz4ibbonubfz7carwiefibzgga",
+  "version": "{version}",
+  "status": "canceled",
+  "input": {
+    "data": "..."
+    "param1": "..."
+  },
+  "output": {
+    "version": "..."
+  },
+  "error": null,
+  "logs": null,
+  "webhook_completed": null,
+  "started_at": "2023-03-28T21:47:58.566434Z",
+  "created_at": "2023-03-28T21:47:58.566434Z",
+  "completed_at": "2023-03-28T21:47:58.566434Z"
+}
+```
+
 ### `replicate.trainings.list`
 
 ```js


### PR DESCRIPTION
This PR makes the following updates to the README:

- Updates the method signature for `trainings.create` (Fixes #82)
- Adds entries for `predictions.cancel` and `trainings.cancel`
- Replaces `{version_id}` placeholders with a real sha
- Updates and reformats example JSON responses