### PR TITLE
Add types to `replicate.request` based on OpenAPI spec

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,20 @@ interface Page<T> {
   results: T[];
 }
 
+/**
+ * Generic to find out if an object type has any required keys
+ */
+type NonOptionalKeys<Obj> = {
+  [K in keyof Obj]: {} extends Pick<Obj, K> ? undefined : K;
+}[keyof Obj];
+
+/**
+ * Make the parameters optional if there is no required parameter
+ */
+export type ArgumentsTypesForRoute<Route extends string, Parameters extends Record<string, unknown>> = NonOptionalKeys<Parameters> extends undefined ? [Route, Parameters?] : [Route, Parameters];
+
 interface RequestInterface {
-  <Route extends keyof Endpoints>(route: Route, parameters?: Endpoints[Route]['parameters']): Promise<Endpoints[Route]['response']>;
+  <Route extends keyof Endpoints>(...options: ArgumentsTypesForRoute<Route, Endpoints[Route]['parameters']>): Promise<Endpoints[Route]['response']>;
 }
 
 export interface Collection {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,139 +1,129 @@
-declare module 'replicate' {
-  type Status = 'starting' | 'processing' | 'succeeded' | 'failed' | 'canceled';
-  type WebhookEventType = 'start' | 'output' | 'logs' | 'completed';
+import { Endpoints } from '@replicate/types-rest-api';
 
-  interface Page<T> {
-    previous?: string;
-    next?: string;
-    results: T[];
-  }
+type Status = 'starting' | 'processing' | 'succeeded' | 'failed' | 'canceled';
+type WebhookEventType = 'start' | 'output' | 'logs' | 'completed';
 
-  export interface Collection {
-    name: string;
-    slug: string;
-    description: string;
-    models?: Model[];
-  }
+interface Page<T> {
+  previous?: string;
+  next?: string;
+  results: T[];
+}
 
-  export interface Model {
-    url: string;
-    owner: string;
-    name: string;
-    description?: string;
-    visibility: 'public' | 'private';
-    github_url?: string;
-    paper_url?: string;
-    license_url?: string;
-    run_count: number;
-    cover_image_url?: string;
-    default_example?: Prediction;
-    latest_version?: ModelVersion;
-  }
+interface RequestInterface {
+  <Route extends keyof Endpoints>(route: Route, parameters?: Endpoints[Route]['parameters']): Promise<Endpoints[Route]['response']>;
+}
 
-  export interface ModelVersion {
-    id: string;
-    created_at: string;
-    cog_version: string;
-    openapi_schema: object;
-  }
+export interface Collection {
+  name: string;
+  slug: string;
+  description: string;
+  models?: Model[];
+}
 
-  export interface Prediction {
-    id: string;
-    status: Status;
-    version: string;
-    input: object;
-    output?: any;
-    source: 'api' | 'web';
-    error?: any;
-    logs?: string;
-    metrics?: {
-      predict_time?: number;
+export interface Model {
+  url: string;
+  owner: string;
+  name: string;
+  description?: string;
+  visibility: 'public' | 'private';
+  github_url?: string;
+  paper_url?: string;
+  license_url?: string;
+  run_count: number;
+  cover_image_url?: string;
+  default_example?: Prediction;
+  latest_version?: ModelVersion;
+}
+
+export interface ModelVersion {
+  id: string;
+  created_at: string;
+  cog_version: string;
+  openapi_schema: object;
+}
+
+export interface Prediction {
+  id: string;
+  status: Status;
+  version: string;
+  input: object;
+  output?: any;
+  source: 'api' | 'web';
+  error?: any;
+  logs?: string;
+  metrics?: {
+    predict_time?: number;
+  };
+  webhook?: string;
+  webhook_events_filter?: WebhookEventType[];
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+}
+
+export type Training = Prediction;
+
+export default class Replicate {
+  constructor(options: { auth: string; userAgent?: string; baseUrl?: string; fetch?: Function });
+
+  auth: string;
+  userAgent?: string;
+  baseUrl?: string;
+  fetch: Function;
+
+  run(
+    identifier: `${string}/${string}:${string}`,
+    options: {
+      input: object;
+      wait?: boolean | { interval?: number; maxAttempts?: number };
+      webhook?: string;
+      webhook_events_filter?: WebhookEventType[];
     }
-    webhook?: string;
-    webhook_events_filter?: WebhookEventType[];
-    created_at: string;
-    updated_at: string;
-    completed_at?: string;
-  }
+  ): Promise<object>;
+  request: RequestInterface;
+  paginate<T>(endpoint: () => Promise<Page<T>>): AsyncGenerator<[T]>;
+  wait(
+    prediction: Prediction,
+    options: {
+      interval?: number;
+      maxAttempts?: number;
+    }
+  ): Promise<Prediction>;
 
-  export type Training = Prediction;
+  collections: {
+    list(): Promise<Page<Collection>>;
+    get(collection_slug: string): Promise<Collection>;
+  };
 
-  export default class Replicate {
-    constructor(options: {
-      auth: string;
-      userAgent?: string;
-      baseUrl?: string;
-      fetch?: Function;
-    });
-
-    auth: string;
-    userAgent?: string;
-    baseUrl?: string;
-    fetch: Function;
-
-    run(
-      identifier: `${string}/${string}:${string}`,
-      options: {
-        input: object;
-        wait?: boolean | { interval?: number; maxAttempts?: number };
-        webhook?: string;
-        webhook_events_filter?: WebhookEventType[];
-      }
-    ): Promise<object>;
-    request(route: string, parameters: any): Promise<any>;
-    paginate<T>(endpoint: () => Promise<Page<T>>): AsyncGenerator<[ T ]>;
-    wait(
-      prediction: Prediction,
-      options: {
-        interval?: number;
-        maxAttempts?: number;
-      }
-    ): Promise<Prediction>;
-
-    collections: {
-      list(): Promise<Page<Collection>>;
-      get(collection_slug: string): Promise<Collection>;
+  models: {
+    get(model_owner: string, model_name: string): Promise<Model>;
+    versions: {
+      list(model_owner: string, model_name: string): Promise<ModelVersion[]>;
+      get(model_owner: string, model_name: string, version_id: string): Promise<ModelVersion>;
     };
+  };
 
-    models: {
-      get(model_owner: string, model_name: string): Promise<Model>;
-      versions: {
-        list(model_owner: string, model_name: string): Promise<ModelVersion[]>;
-        get(
-          model_owner: string,
-          model_name: string,
-          version_id: string
-        ): Promise<ModelVersion>;
-      };
-    };
+  predictions: {
+    create(options: { version: string; input: object; webhook?: string; webhook_events_filter?: WebhookEventType[] }): Promise<Prediction>;
+    get(prediction_id: string): Promise<Prediction>;
+    cancel(prediction_id: string): Promise<Prediction>;
+    list(): Promise<Page<Prediction>>;
+  };
 
-    predictions: {
-      create(options: {
-        version: string;
+  trainings: {
+    create(
+      model_owner: string,
+      model_name: string,
+      version_id: string,
+      options: {
+        destination: `${string}/${string}`;
         input: object;
         webhook?: string;
         webhook_events_filter?: WebhookEventType[];
-      }): Promise<Prediction>;
-      get(prediction_id: string): Promise<Prediction>;
-      cancel(prediction_id: string): Promise<Prediction>;
-      list(): Promise<Page<Prediction>>;
-    };
-
-    trainings: {
-      create(
-        model_owner: string,
-        model_name: string,
-        version_id: string,
-        options: {
-          destination: `${string}/${string}`;
-          input: object;
-          webhook?: string;
-          webhook_events_filter?: WebhookEventType[];
-        }
-      ): Promise<Training>;
-      get(training_id: string): Promise<Training>;
-      cancel(training_id: string): Promise<Training>;
-      list(): Promise<Page<Training>>;
-    };
-  }
+      }
+    ): Promise<Training>;
+    get(training_id: string): Promise<Training>;
+    cancel(training_id: string): Promise<Training>;
+    list(): Promise<Page<Training>>;
+  };
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -10,6 +10,9 @@ export async function requestTest() {
   // @ts-expect-error - unknown route
   replicate.request('GET /unknown');
 
+  // @ts-expect-error - required arugments not passed
+  replicate.request('POST /v1/models/{model_owner}/{model_name}/versions/{version_id}/trainings');
+
   replicate.request('POST /v1/models/{model_owner}/{model_name}/versions/{version_id}/trainings', {
     model_owner: 'test',
     model_name: 'test',

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,21 @@
+import Replicate from '.';
+
+export async function requestTest() {
+  const replicate = new Replicate({
+    auth: '',
+  });
+
+  replicate.request('GET /v1/collections');
+
+  // @ts-expect-error - unknown route
+  replicate.request('GET /unknown');
+
+  replicate.request('POST /v1/models/{model_owner}/{model_name}/versions/{version_id}/trainings', {
+    model_owner: 'test',
+    model_name: 'test',
+    version_id: 'test',
+
+    // @ts-expect-error - unknown parameter
+    unknown: 'test',
+  });
+}

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,7 +1,8 @@
 import { expect, jest, test } from '@jest/globals';
-import Replicate, { Prediction } from 'replicate';
 import nock from 'nock';
 import fetch from 'cross-fetch';
+
+import Replicate, { Prediction } from '.';
 
 describe('Replicate client', () => {
   let client: Replicate;
@@ -35,7 +36,7 @@ describe('Replicate client', () => {
     });
 
     test('Throws error if no auth token is provided', () => {
-      const expected = 'Missing required parameter: auth'
+      const expected = 'Missing required parameter: auth';
 
       expect(() => {
         new Replicate({ auth: undefined });
@@ -46,7 +47,7 @@ describe('Replicate client', () => {
       }).toThrow(expected);
 
       expect(() => {
-        new Replicate({ auth: "" });
+        new Replicate({ auth: '' });
       }).toThrow(expected);
     });
   });
@@ -121,12 +122,10 @@ describe('Replicate client', () => {
         .post('/predictions')
         .reply(200, {
           id: 'ufawqhfynnddngldkgtslldrkq',
-          version:
-            '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
+          version: '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
           urls: {
             get: 'https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq',
-            cancel:
-              'https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel',
+            cancel: 'https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel',
           },
           created_at: '2022-04-26T22:13:06.224088Z',
           started_at: null,
@@ -141,13 +140,12 @@ describe('Replicate client', () => {
           metrics: {},
         });
       const prediction = await client.predictions.create({
-        version:
-          '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
+        version: '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
         input: {
           text: 'Alice',
         },
         webhook: 'http://test.host/webhook',
-        webhook_events_filter: [ 'output', 'completed' ],
+        webhook_events_filter: ['output', 'completed'],
       });
       expect(prediction.id).toBe('ufawqhfynnddngldkgtslldrkq');
     });
@@ -172,12 +170,10 @@ describe('Replicate client', () => {
         .get('/predictions/rrr4z55ocneqzikepnug6xezpe')
         .reply(200, {
           id: 'rrr4z55ocneqzikepnug6xezpe',
-          version:
-            'be04660a5b93ef2aff61e3668dedb4cbeb14941e62a3fd5998364a32d613e35e',
+          version: 'be04660a5b93ef2aff61e3668dedb4cbeb14941e62a3fd5998364a32d613e35e',
           urls: {
             get: 'https://api.replicate.com/v1/predictions/rrr4z55ocneqzikepnug6xezpe',
-            cancel:
-              'https://api.replicate.com/v1/predictions/rrr4z55ocneqzikepnug6xezpe/cancel',
+            cancel: 'https://api.replicate.com/v1/predictions/rrr4z55ocneqzikepnug6xezpe/cancel',
           },
           created_at: '2022-09-13T22:54:18.578761Z',
           started_at: '2022-09-13T22:54:19.438525Z',
@@ -187,18 +183,14 @@ describe('Replicate client', () => {
           input: {
             prompt: 'oak tree with boletus growing on its branches',
           },
-          output: [
-            'https://replicate.com/api/models/stability-ai/stable-diffusion/files/9c3b6fe4-2d37-4571-a17a-83951b1cb120/out-0.png',
-          ],
+          output: ['https://replicate.com/api/models/stability-ai/stable-diffusion/files/9c3b6fe4-2d37-4571-a17a-83951b1cb120/out-0.png'],
           error: null,
           logs: 'Using seed: 36941...',
           metrics: {
             predict_time: 4.484541,
           },
         });
-      const prediction = await client.predictions.get(
-        'rrr4z55ocneqzikepnug6xezpe'
-      );
+      const prediction = await client.predictions.get('rrr4z55ocneqzikepnug6xezpe');
       expect(prediction.id).toBe('rrr4z55ocneqzikepnug6xezpe');
     });
     // Add more tests for error handling, edge cases, etc.
@@ -210,12 +202,10 @@ describe('Replicate client', () => {
         .post('/predictions/ufawqhfynnddngldkgtslldrkq/cancel')
         .reply(200, {
           id: 'ufawqhfynnddngldkgtslldrkq',
-          version:
-            '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
+          version: '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
           urls: {
             get: 'https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq',
-            cancel:
-              'https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel',
+            cancel: 'https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel',
           },
           created_at: '2022-04-26T22:13:06.224088Z',
           started_at: '2022-04-26T22:13:06.224088Z',
@@ -230,9 +220,7 @@ describe('Replicate client', () => {
           metrics: {},
         });
 
-      const prediction = await client.predictions.cancel(
-        'ufawqhfynnddngldkgtslldrkq'
-      );
+      const prediction = await client.predictions.cancel('ufawqhfynnddngldkgtslldrkq');
       expect(prediction.status).toBe('canceled');
     });
 
@@ -249,12 +237,10 @@ describe('Replicate client', () => {
           results: [
             {
               id: 'jpzd7hm5gfcapbfyt4mqytarku',
-              version:
-                'b21cbe271e65c1718f2999b038c18b45e21e4fba961181fbfae9342fc53b9e05',
+              version: 'b21cbe271e65c1718f2999b038c18b45e21e4fba961181fbfae9342fc53b9e05',
               urls: {
                 get: 'https://api.replicate.com/v1/predictions/jpzd7hm5gfcapbfyt4mqytarku',
-                cancel:
-                  'https://api.replicate.com/v1/predictions/jpzd7hm5gfcapbfyt4mqytarku/cancel',
+                cancel: 'https://api.replicate.com/v1/predictions/jpzd7hm5gfcapbfyt4mqytarku/cancel',
               },
               created_at: '2022-04-26T20:00:40.658234Z',
               started_at: '2022-04-26T20:00:84.583803Z',
@@ -267,21 +253,19 @@ describe('Replicate client', () => {
 
       const predictions = await client.predictions.list();
       expect(predictions.results.length).toBe(1);
-      expect(predictions.results[ 0 ].id).toBe('jpzd7hm5gfcapbfyt4mqytarku');
+      expect(predictions.results[0].id).toBe('jpzd7hm5gfcapbfyt4mqytarku');
     });
 
     test('Paginates results', async () => {
       nock(BASE_URL)
         .get('/predictions')
         .reply(200, {
-          results: [ { id: 'ufawqhfynnddngldkgtslldrkq' } ],
+          results: [{ id: 'ufawqhfynnddngldkgtslldrkq' }],
           next: 'https://api.replicate.com/v1/predictions?cursor=cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw',
         })
-        .get(
-          '/predictions?cursor=cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw'
-        )
+        .get('/predictions?cursor=cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw')
         .reply(200, {
-          results: [ { id: 'rrr4z55ocneqzikepnug6xezpe' } ],
+          results: [{ id: 'rrr4z55ocneqzikepnug6xezpe' }],
           next: null,
         });
 
@@ -289,10 +273,7 @@ describe('Replicate client', () => {
       for await (const batch of client.paginate(client.predictions.list)) {
         results.push(...batch);
       }
-      expect(results).toEqual([
-        { id: 'ufawqhfynnddngldkgtslldrkq' },
-        { id: 'rrr4z55ocneqzikepnug6xezpe' },
-      ]);
+      expect(results).toEqual([{ id: 'ufawqhfynnddngldkgtslldrkq' }, { id: 'rrr4z55ocneqzikepnug6xezpe' }]);
 
       // Add more tests for error handling, edge cases, etc.
     });
@@ -301,9 +282,7 @@ describe('Replicate client', () => {
   describe('trainings.create', () => {
     test('Calls the correct API route with the correct payload', async () => {
       nock(BASE_URL)
-        .post(
-          '/models/owner/model/versions/632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532/trainings'
-        )
+        .post('/models/owner/model/versions/632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532/trainings')
         .reply(200, {
           id: 'zz4ibbonubfz7carwiefibzgga',
           version: '{version}',
@@ -319,34 +298,24 @@ describe('Replicate client', () => {
           completed_at: null,
         });
 
-      const training = await client.trainings.create(
-        'owner',
-        'model',
-        '632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532',
-        {
-          destination: 'new_owner/new_model',
-          input: {
-            text: '...',
-          },
-        }
-      );
+      const training = await client.trainings.create('owner', 'model', '632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532', {
+        destination: 'new_owner/new_model',
+        input: {
+          text: '...',
+        },
+      });
       expect(training.id).toBe('zz4ibbonubfz7carwiefibzgga');
     });
 
     test('Throws an error if webhook is not a valid URL', async () => {
       await expect(
-        client.trainings.create(
-          'owner',
-          'model',
-          '632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532',
-          {
-            destination: 'new_owner/new_model',
-            input: {
-              text: '...',
-            },
-            webhook: 'invalid-url',
-          }
-        )
+        client.trainings.create('owner', 'model', '632231d0d49d34d5c4633bd838aee3d81d936e59a886fbf28524702003b4c532', {
+          destination: 'new_owner/new_model',
+          input: {
+            text: '...',
+          },
+          webhook: 'invalid-url',
+        })
       ).rejects.toThrow('Invalid webhook URL');
     });
 
@@ -406,9 +375,7 @@ describe('Replicate client', () => {
           completed_at: null,
         });
 
-      const training = await client.trainings.cancel(
-        'zz4ibbonubfz7carwiefibzgga'
-      );
+      const training = await client.trainings.cancel('zz4ibbonubfz7carwiefibzgga');
       expect(training.status).toBe('canceled');
     });
 
@@ -425,12 +392,10 @@ describe('Replicate client', () => {
           results: [
             {
               id: 'jpzd7hm5gfcapbfyt4mqytarku',
-              version:
-                'b21cbe271e65c1718f2999b038c18b45e21e4fba961181fbfae9342fc53b9e05',
+              version: 'b21cbe271e65c1718f2999b038c18b45e21e4fba961181fbfae9342fc53b9e05',
               urls: {
                 get: 'https://api.replicate.com/v1/trainings/jpzd7hm5gfcapbfyt4mqytarku',
-                cancel:
-                  'https://api.replicate.com/v1/trainings/jpzd7hm5gfcapbfyt4mqytarku/cancel',
+                cancel: 'https://api.replicate.com/v1/trainings/jpzd7hm5gfcapbfyt4mqytarku/cancel',
               },
               created_at: '2022-04-26T20:00:40.658234Z',
               started_at: '2022-04-26T20:00:84.583803Z',
@@ -443,21 +408,19 @@ describe('Replicate client', () => {
 
       const trainings = await client.trainings.list();
       expect(trainings.results.length).toBe(1);
-      expect(trainings.results[ 0 ].id).toBe('jpzd7hm5gfcapbfyt4mqytarku');
+      expect(trainings.results[0].id).toBe('jpzd7hm5gfcapbfyt4mqytarku');
     });
 
     test('Paginates results', async () => {
       nock(BASE_URL)
         .get('/trainings')
         .reply(200, {
-          results: [ { id: 'ufawqhfynnddngldkgtslldrkq' } ],
+          results: [{ id: 'ufawqhfynnddngldkgtslldrkq' }],
           next: 'https://api.replicate.com/v1/trainings?cursor=cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw',
         })
-        .get(
-          '/trainings?cursor=cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw'
-        )
+        .get('/trainings?cursor=cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw')
         .reply(200, {
-          results: [ { id: 'rrr4z55ocneqzikepnug6xezpe' } ],
+          results: [{ id: 'rrr4z55ocneqzikepnug6xezpe' }],
           next: null,
         });
 
@@ -465,10 +428,7 @@ describe('Replicate client', () => {
       for await (const batch of client.paginate(client.trainings.list)) {
         results.push(...batch);
       }
-      expect(results).toEqual([
-        { id: 'ufawqhfynnddngldkgtslldrkq' },
-        { id: 'rrr4z55ocneqzikepnug6xezpe' },
-      ]);
+      expect(results).toEqual([{ id: 'ufawqhfynnddngldkgtslldrkq' }, { id: 'rrr4z55ocneqzikepnug6xezpe' }]);
 
       // Add more tests for error handling, edge cases, etc.
     });
@@ -489,12 +449,9 @@ describe('Replicate client', () => {
           output: 'foobar',
         });
 
-      const output = await client.run(
-        'owner/model:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
-        {
-          input: { text: 'Hello, world!' },
-        }
-      );
+      const output = await client.run('owner/model:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa', {
+        input: { text: 'Hello, world!' },
+      });
       expect(output).toBe('foobar');
     });
 
@@ -516,7 +473,7 @@ describe('Replicate client', () => {
     });
 
     test('Throws an error for invalid identifiers', async () => {
-      const options = { input: { text: 'Hello, world!' } }
+      const options = { input: { text: 'Hello, world!' } };
 
       await expect(client.run('owner/model:invalid', options)).rejects.toThrow();
 
@@ -531,8 +488,7 @@ describe('Replicate client', () => {
 
     test('Throws an error if webhook URL is invalid', async () => {
       await expect(async () => {
-        await client.run(
-          'owner/model:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa', {
+        await client.run('owner/model:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa', {
           input: {
             text: 'Alice',
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "replicate",
       "version": "0.12.3",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@replicate/types-rest-api": "^2.4.1"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
@@ -22,6 +25,7 @@
         "jest": "^29.5.0",
         "nock": "^13.3.0",
         "ts-jest": "^29.1.0",
+        "tsd": "^0.28.1",
         "typescript": "^5.0.2"
       },
       "engines": {
@@ -1215,6 +1219,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@replicate/types-openapi": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@replicate/types-openapi/-/types-openapi-2.4.1.tgz",
+      "integrity": "sha512-AYbJuHhHcB+EbuVGbC4nRgXRYPxAakvuVdj3R5rxdsZjvWLWStPJCUJ7hcD9QxdLaPJ5xVsjgc7i7vZqKONYfQ=="
+    },
+    "node_modules/@replicate/types-rest-api": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@replicate/types-rest-api/-/types-rest-api-2.4.1.tgz",
+      "integrity": "sha512-Oc+nAcMAgSgU9F6RUChi187uJrRGYLO2WL+Cm7XG3dfrERs401YC1zAWyRyqQOE3rZxe/UbvR9Cc7Oi9dlZJNw==",
+      "dependencies": {
+        "@replicate/types-openapi": "^2.4.1"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -1238,6 +1255,12 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "node_modules/@tsd/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -1279,6 +1302,22 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -1335,10 +1374,22 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.15.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
       "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1756,6 +1807,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1994,6 +2054,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001469",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
@@ -2169,6 +2246,40 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -2477,6 +2588,28 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
@@ -2708,6 +2841,12 @@
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -3278,6 +3417,15 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3359,6 +3507,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3427,6 +3605,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3455,6 +3642,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/irregular-plurals": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3643,6 +3839,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -3730,6 +3935,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakref": {
@@ -4468,6 +4685,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4538,6 +4764,22 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4586,6 +4828,65 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4623,6 +4924,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4642,6 +4952,20 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ms": {
@@ -4708,6 +5032,21 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5040,6 +5379,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "dependencies": {
+        "irregular-plurals": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5142,11 +5496,162 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -5412,6 +5917,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
@@ -5563,6 +6078,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5582,6 +6109,19 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -5651,6 +6191,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ts-jest": {
       "version": "29.1.0",
@@ -5726,6 +6275,27 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tsd": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.28.1.tgz",
+      "integrity": "sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==",
+      "dev": true,
+      "dependencies": {
+        "@tsd/typescript": "~5.0.2",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "jest-diff": "^29.0.3",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "bin": {
+        "tsd": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "node_modules/tslib": {
@@ -5878,6 +6448,16 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest & tsd"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
@@ -31,6 +31,10 @@
     "jest": "^29.5.0",
     "nock": "^13.3.0",
     "ts-jest": "^29.1.0",
+    "tsd": "^0.28.1",
     "typescript": "^5.0.2"
+  },
+  "dependencies": {
+    "@replicate/types-rest-api": "^2.4.1"
   }
 }


### PR DESCRIPTION
When using an editor that supports type IntelliSense, the editor will automatically suggest all known routes based on Replicate's OpenAPI specification as well as its corresponding types.

~~Right now, the `parameters` key is always set to optional. But it should be required if at least one query or body parameter is required. It's something I've solved in Octokit but somehow couldn't get it to work for `replicate.request` yet. But this is still good to go, we can improve the type later.~~ All fixed now

Once we have the types working for `replicate.request`, generating all REST API methods based on the OpenAPI spec is fairly simple.

https://github.com/replicate/replicate-javascript/assets/39992/0276dc20-3ae1-42ad-87aa-34ad21c615da
