### PR TITLE
Document how to customize client requests by setting `fetch` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ const replicate = new Replicate({
 });
 ```
 
+You can override the `fetch` property to add custom behavior to client requests,
+such as injecting headers or adding log statements.
+
+```js
+client.fetch = (url, options) => {
+  const headers = new Headers(options && options.headers);
+  headers.append("X-Custom-Header", "some value");
+
+  console.log("fetch", { url, ...options, headers });
+
+  return fetch(url, { ...options, headers });
+};
+```
+
 ### `replicate.models.get`
 
 ```js


### PR DESCRIPTION
Related to #95 

This PR updates the README to show how the `fetch` property can be set to customize client behavior.