### PR TITLE
Provide more information in API errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,9 @@ declare module 'replicate' {
   type Status = 'starting' | 'processing' | 'succeeded' | 'failed' | 'canceled';
   type WebhookEventType = 'start' | 'output' | 'logs' | 'completed';
 
-  interface Page<T> {
-    previous?: string;
-    next?: string;
-    results: T[];
+  export interface ApiError extends Error {
+    request: Request;
+    response: Response;
   }
 
   export interface Collection {
@@ -57,6 +56,12 @@ declare module 'replicate' {
   }
 
   export type Training = Prediction;
+
+  interface Page<T> {
+    previous?: string;
+    next?: string;
+    results: T[];
+  }
 
   export default class Replicate {
     constructor(options: {

--- a/index.test.ts
+++ b/index.test.ts
@@ -163,6 +163,29 @@ describe('Replicate client', () => {
         });
       }).rejects.toThrow('Invalid webhook URL');
     });
+
+    test('Throws an error with details failing response is JSON', async () => {
+      nock(BASE_URL)
+        .post('/predictions')
+        .reply(400, {
+          status: 400,
+          detail: "Invalid input",
+        }, { "Content-Type": "application/json" })
+
+      try {
+        expect.assertions(2);
+
+        await client.predictions.create({
+          version: '5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
+          input: {
+            text: null,
+          },
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(400);
+        expect(error.message).toContain("Invalid input")
+      }
+    })
     // Add more tests for error handling, edge cases, etc.
   });
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,17 @@
+class ApiError extends Error {
+  /**
+   * Creates a representation of an API error.
+   * @param {string} message - Error message
+   * @param {Request} request - HTTP request
+   * @param {Response} response - HTTP response
+   * @returns {ApiError}
+   */
+  constructor(message, request, response) {
+    super(message);
+    this.name = 'ApiError';
+    this.request = request;
+    this.response = response;
+  }
+}
+
+module.exports = ApiError;


### PR DESCRIPTION
For example, if a user tries to call `replicate.trainings.create` on a method that doesn't support trainings, they'll see the error message `API request failed:: Bad request`. Information for why the operation failed ("{version_id} is not a trainable model version!"} isn't provided to the consumer.

This PR introduces a new `ApiError` class that encapsulates API error responses. By throwing this instead of a bare string, consumers can get the failing `request` and `response`. This object also improves the default message to include the text of the response.