### PR TITLE
Fix `jsdoc/tag-lines` linter rule setting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,6 @@ module.exports = {
     'max-len': 'off',
     'operator-linebreak': 'off',
     'jsdoc/require-param-description': 'off',
+    'jsdoc/tag-lines': ['error', 'any', { startLines: 1 }],
   },
 };

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,10 +1,11 @@
 class ApiError extends Error {
   /**
    * Creates a representation of an API error.
+   *
    * @param {string} message - Error message
    * @param {Request} request - HTTP request
    * @param {Response} response - HTTP response
-   * @returns {ApiError}
+   * @returns {ApiError} - An instance of ApiError
    */
   constructor(message, request, response) {
     super(message);


### PR DESCRIPTION
This PR also fixes some linting errors in `ApiError` introduced by #103.