### PR TITLE
Add abort signal option to `run` method and stop callback to `wait` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ declare module 'replicate' {
         wait?: { interval?: number; max_attempts?: number };
         webhook?: string;
         webhook_events_filter?: WebhookEventType[];
+        signal?: AbortSignal;
       }
     ): Promise<object>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,7 +105,8 @@ declare module 'replicate' {
       options: {
         interval?: number;
         max_attempts?: number;
-      }
+      },
+      stop?: (Prediction) => Promise<boolean>
     ): Promise<Prediction>;
 
     collections: {

--- a/index.js
+++ b/index.js
@@ -219,11 +219,12 @@ class Replicate {
    * @param {object} options - Options
    * @param {number} [options.interval] - Polling interval in milliseconds. Defaults to 250
    * @param {number} [options.max_attempts] - Maximum number of polling attempts. Defaults to no limit
+   * @param {Function} [stop] - Async callback function that is called after each polling attempt. Receives the prediction object as an argument. Return false to cancel polling.
    * @throws {Error} If the prediction doesn't complete within the maximum number of attempts
    * @throws {Error} If the prediction failed
    * @returns {Promise<object>} Resolves with the completed prediction object
    */
-  async wait(prediction, options) {
+  async wait(prediction, options, stop) {
     const { id } = prediction;
     if (!id) {
       throw new Error('Invalid prediction');
@@ -261,6 +262,9 @@ class Replicate {
       /* eslint-disable no-await-in-loop */
       await sleep(interval);
       updatedPrediction = await this.predictions.get(prediction.id);
+      if (stop && await stop(updatedPrediction) === true) {
+        break;
+      }
       /* eslint-enable no-await-in-loop */
     }
 


### PR DESCRIPTION
> The `AbortController` interface represents a controller object that allows you to abort one or more Web requests as and when desired.

This PR adds a `signal` option to the `run` method. Normally, the `run` method creates a prediction and then waits until it finishes. Because it doesn't return an intermediate value (unlike `predictions.create`), there's no mechanism for stopping and canceling the prediction until after it's completed.

This PR also adds a `stop` parameter to the `wait` method, which is used in the implementation of the abort signal. With this change, you can now pass a function as an argument to `wait` that takes a prediction as an argument and returns a promise for a Boolean. If this callback returns `true`, then the `wait` stops polling and returns. This callback also provides a way to monitor progress as the predictions updates.
