### PR TITLE
Add progress callback parameter to `run` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,7 +89,8 @@ declare module 'replicate' {
         webhook?: string;
         webhook_events_filter?: WebhookEventType[];
         signal?: AbortSignal;
-      }
+      },
+      progress?: (Prediction) => void
     ): Promise<object>;
 
     request(route: string | URL, options: {

--- a/index.js
+++ b/index.js
@@ -86,10 +86,11 @@ class Replicate {
    * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
    * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
    * @param {AbortSignal} [options.signal] - AbortSignal to cancel the prediction
+   * @param {Function} [progress] - Callback function that receives the prediction object as it's updated. The function is called when the prediction is created, each time its updated while polling for completion, and when it's completed.
    * @throws {Error} If the prediction failed
    * @returns {Promise<object>} - Resolves with the output of running the model
    */
-  async run(identifier, options) {
+  async run(identifier, options, progress) {
     const { wait, ...data } = options;
 
     // Define a pattern for owner and model names that allows
@@ -117,16 +118,31 @@ class Replicate {
       version,
     });
 
+    // Call progress callback with the initial prediction object
+    if (progress) {
+      progress(prediction);
+    }
+
     const { signal } = options;
 
-    prediction = await this.wait(prediction, wait || {}, async ({ id }) => {
+    prediction = await this.wait(prediction, wait || {}, async (updatedPrediction) => {
+      // Call progress callback with the updated prediction object
+      if (progress) {
+        progress(updatedPrediction);
+      }
+
       if (signal && signal.aborted) {
-        await this.predictions.cancel(id);
+        await this.predictions.cancel(updatedPrediction.id);
         return true; // stop polling
       }
 
       return false; // continue polling
     });
+
+    // Call progress callback with the completed prediction object
+    if (progress) {
+      progress(prediction);
+    }
 
     if (prediction.status === 'failed') {
       throw new Error(`Prediction failed: ${prediction.error}`);


### PR DESCRIPTION
Follow up to #106 

This PR adds a `progress` callback parameter to the `run` method. The function is called with the prediction initially after creation, after each polling update, and after completion.

```js
const model = "stability-ai/stable-diffusion:27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478";
const input = {
  prompt: "a 19th century portrait of a raccoon gentleman wearing a suit",
};
const output = await replicate.run(model, { input }, (prediction) => {
  console.log(prediction)
});
```

This PR also fixes a bug in the implementation of the `wait` method's `stop` parameter, where the callback wasn't called after the first polling request.