### PR TITLE
Change polling behavior

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ declare module 'replicate' {
       identifier: `${string}/${string}:${string}`,
       options: {
         input: object;
-        wait?: { interval?: number; max_attempts?: number };
+        wait?: { interval?: number };
         webhook?: string;
         webhook_events_filter?: WebhookEventType[];
         signal?: AbortSignal;
@@ -106,7 +106,6 @@ declare module 'replicate' {
       prediction: Prediction,
       options: {
         interval?: number;
-        max_attempts?: number;
       },
       stop?: (prediction: Prediction) => Promise<boolean>
     ): Promise<Prediction>;

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ class Replicate {
    * @param {object} options
    * @param {object} options.input - Required. An object with the model inputs
    * @param {object} [options.wait] - Options for waiting for the prediction to finish
-   * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
+   * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 500
    * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
    * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
    * @param {AbortSignal} [options.signal] - AbortSignal to cancel the prediction
@@ -246,7 +246,7 @@ class Replicate {
    * @async
    * @param {object} prediction - Prediction object
    * @param {object} options - Options
-   * @param {number} [options.interval] - Polling interval in milliseconds. Defaults to 250
+   * @param {number} [options.interval] - Polling interval in milliseconds. Defaults to 500
    * @param {Function} [stop] - Async callback function that is called after each polling attempt. Receives the prediction object as an argument. Return false to cancel polling.
    * @throws {Error} If the prediction doesn't complete within the maximum number of attempts
    * @throws {Error} If the prediction failed
@@ -269,7 +269,7 @@ class Replicate {
     // eslint-disable-next-line no-promise-executor-return
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    const interval = options.interval || 250;
+    const interval = options.interval || 500;
 
     let updatedPrediction = await this.predictions.get(id);
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ class Replicate {
    * @param {object} options.input - Required. An object with the model inputs
    * @param {object} [options.wait] - Options for waiting for the prediction to finish
    * @param {number} [options.wait.interval] - Polling interval in milliseconds. Defaults to 250
-   * @param {number} [options.wait.max_attempts] - Maximum number of polling attempts. Defaults to no limit
    * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
    * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
    * @param {AbortSignal} [options.signal] - AbortSignal to cancel the prediction
@@ -248,7 +247,6 @@ class Replicate {
    * @param {object} prediction - Prediction object
    * @param {object} options - Options
    * @param {number} [options.interval] - Polling interval in milliseconds. Defaults to 250
-   * @param {number} [options.max_attempts] - Maximum number of polling attempts. Defaults to no limit
    * @param {Function} [stop] - Async callback function that is called after each polling attempt. Receives the prediction object as an argument. Return false to cancel polling.
    * @throws {Error} If the prediction doesn't complete within the maximum number of attempts
    * @throws {Error} If the prediction failed
@@ -271,9 +269,7 @@ class Replicate {
     // eslint-disable-next-line no-promise-executor-return
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    let attempts = 0;
     const interval = options.interval || 250;
-    const max_attempts = options.max_attempts || null;
 
     let updatedPrediction = await this.predictions.get(id);
 
@@ -285,13 +281,6 @@ class Replicate {
       /* eslint-disable no-await-in-loop */
       if (stop && await stop(updatedPrediction) === true) {
         break;
-      }
-
-      attempts += 1;
-      if (max_attempts && attempts > max_attempts) {
-        throw new Error(
-          `Prediction ${id} did not finish after ${max_attempts} attempts`
-        );
       }
 
       await sleep(interval);


### PR DESCRIPTION
Related to #106 

This PR makes the following two changes to the `wait` method:

- Removes the `max_attempts` option. To stop polling for a prediction to complete, you can either return `false` in a callback passed to the `stop` parameter of the `wait` method, or call `predictions.cancel`. Or if polling via the `run` method, you can pass an `AbortSignal` to the `signal` property.
- Updates the polling interval for a prediction from 250ms to 500ms. This is a more reasonable default for most use cases, and it brings this project in line with the Python client's behavior.
