### PR TITLE
Add automatic retry policy

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,69 @@
+const ApiError = require('./error');
+
+/**
+ * Automatically retry a request if it fails with an appropriate status code.
+ *
+ * A GET request is retried if it fails with a 429 or 5xx status code.
+ * A non-GET request is retried only if it fails with a 429 status code.
+ *
+ * If the response sets a Retry-After header,
+ * the request is retried after the number of seconds specified in the header.
+ * Otherwise, the request is retried after the specified interval,
+ * with exponential backoff and jitter.
+ *
+ * @param {Function} request - A function that returns a Promise that resolves with a Response object
+ * @param {object} options
+ * @param {Function} [options.shouldRetry] - A function that returns true if the request should be retried
+ * @param {number} [options.maxRetries] - Maximum number of retries. Defaults to 5
+ * @param {number} [options.interval] - Interval between retries in milliseconds. Defaults to 500
+ * @returns {Promise<Response>} - Resolves with the response object
+ * @throws {ApiError} If the request failed
+ */
+async function withAutomaticRetries(request, options = {}) {
+  const shouldRetry = options.shouldRetry || (() => (false));
+  const maxRetries = options.maxRetries || 5;
+  const interval = options.interval || 500;
+  const jitter = options.jitter || 100;
+
+  // eslint-disable-next-line no-promise-executor-return
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  let attempts = 0;
+  do {
+    let delay = (interval * (2 ** attempts)) + (Math.random() * jitter);
+
+    /* eslint-disable no-await-in-loop */
+    try {
+      const response = await request();
+      if (response.ok || !shouldRetry(response)) {
+        return response;
+      }
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const retryAfter = error.response.headers.get('Retry-After');
+        if (retryAfter) {
+          if (!Number.isInteger(retryAfter)) { // Retry-After is a date
+            const date = new Date(retryAfter);
+            if (!Number.isNaN(date.getTime())) {
+              delay = date.getTime() - new Date().getTime();
+            }
+          } else { // Retry-After is a number of seconds
+            delay = retryAfter * 1000;
+          }
+        }
+      }
+    }
+
+    if (Number.isInteger(maxRetries) && maxRetries > 0) {
+      if (Number.isInteger(delay) && delay > 0) {
+        await sleep(interval * 2 ** (options.maxRetries - maxRetries));
+      }
+      attempts += 1;
+    }
+    /* eslint-enable no-await-in-loop */
+  } while (attempts < maxRetries);
+
+  return request();
+}
+
+module.exports = { withAutomaticRetries };


### PR DESCRIPTION
Related to #114

This PR introduces a new `withAutomaticRetry` function that wraps requests made with `fetch` to automatically retry them as appropriate (429 status code, as well as 5xx errors for `GET` requests). If the server sends a `Retry-After` header, that value is used. Otherwise, the function delays for a configured interval with exponential backoff and jitter.

This should all be in line with the [retry logic in the Python client](https://github.com/replicate/replicate-python/blob/52f88eb3349c92c33608549ef992792172f951ed/replicate/client.py#L17-L63). 