### PR TITLE
Specify minimum engine requirement of Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=18.0.0",
     "npm": ">=7.19.0",
     "git": ">=2.11.0",
     "yarn": ">=1.7.0"


### PR DESCRIPTION
Several issues have been opened with questions or problems related to `fetch` and Node.js versions.

- https://github.com/replicate/replicate-javascript/issues/69
- https://github.com/replicate/replicate-javascript/issues/93
- https://github.com/replicate/replicate-javascript/issues/100
- https://github.com/replicate/replicate-javascript/issues/116

In #100, I wrote:

> Replicate should work on any supported version of Node provided that there's a `fetch` function available, so I'm not sure updating the engines for the package would be appropriate.

That comment was based on an incorrect understanding of npm. According to [the docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines), engine requirements are advisory, and don't prevent a client from installing a package Unless the user has set the [engine-strict config](https://docs.npmjs.com/cli/v9/using-npm/config#engine-strict) flag.

This PR sets the `engines` key in the `package.json` file to specify a requirement of Node >= 18.0.0.
