### PR TITLE
defer auth check until request time

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,6 @@ class Replicate {
    * @param {Function} [options.fetch] - Fetch function to use. Defaults to `globalThis.fetch`
    */
   constructor(options) {
-    if (!options.auth) {
-      throw new Error('Missing required parameter: auth');
-    }
-
     this.auth = options.auth;
     this.userAgent =
       options.userAgent || `replicate-javascript/${packageJSON.version}`;
@@ -165,6 +161,10 @@ class Replicate {
    */
   async request(route, options) {
     const { auth, baseUrl, userAgent } = this;
+
+    if (!auth) {
+      throw new Error('Not authenticated. Set `auth` option when initializing the Replicate client.');
+    }
 
     let url;
     if (route instanceof URL) {

--- a/index.test.ts
+++ b/index.test.ts
@@ -33,14 +33,6 @@ describe('Replicate client', () => {
       });
       expect(clientWithCustomUserAgent.userAgent).toBe('my-app/1.2.3');
     });
-
-    test('Throws error if no auth token is provided', () => {
-      const expected = 'Missing required parameter: auth'
-
-      expect(() => {
-        new Replicate({ auth: "" });
-      }).toThrow(expected);
-    });
   });
 
   describe('collections.list', () => {
@@ -666,6 +658,14 @@ describe('Replicate client', () => {
 
       // @ts-expect-error
       await expect(client.run(':abc123', options)).rejects.toThrow();
+    });
+
+    test('Throws an error if client was initialized without auth', async () => {
+      // @ts-expect-error
+      client = new Replicate({});
+
+      const expected = 'Not authenticated';
+      await expect(client.run('owner/model:5c7d5dc6', { input: { query: 'hello' } })).rejects.toThrow(expected);
     });
 
     test('Throws an error if webhook URL is invalid', async () => {


### PR DESCRIPTION
Check for auth when an API request is made, instead of checking at runtime.

See https://github.com/replicate/llama-chat/pull/19#issuecomment-1662946025