### PR TITLE
Don't throw error if auth isn't provided in client constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,7 @@ class Replicate {
    * @param {string} [options.baseUrl] - Defaults to https://api.replicate.com/v1
    * @param {Function} [options.fetch] - Fetch function to use. Defaults to `globalThis.fetch`
    */
-  constructor(options) {
-    if (!options.auth) {
-      throw new Error('Missing required parameter: auth');
-    }
-
+  constructor(options = {}) {
     this.auth = options.auth;
     this.userAgent =
       options.userAgent || `replicate-javascript/${packageJSON.version}`;
@@ -187,7 +183,9 @@ class Replicate {
     });
 
     const headers = new Headers();
-    headers.append('Authorization', `Token ${auth}`);
+    if (auth) {
+      headers.append('Authorization', `Token ${auth}`);
+    }
     headers.append('Content-Type', 'application/json');
     headers.append('User-Agent', userAgent);
     if (options.headers) {

--- a/index.test.ts
+++ b/index.test.ts
@@ -34,12 +34,17 @@ describe('Replicate client', () => {
       expect(clientWithCustomUserAgent.userAgent).toBe('my-app/1.2.3');
     });
 
-    test('Throws error if no auth token is provided', () => {
-      const expected = 'Missing required parameter: auth'
+    test('Does not throw error if auth token is not provided', () => {
+      expect(() => {
+        // @ts-expect-error
+        new Replicate();
+      }).not.toThrow();
+    });
 
+    test('Does not throw error if blank auth token is provided', () => {
       expect(() => {
         new Replicate({ auth: "" });
-      }).toThrow(expected);
+      }).not.toThrow();
     });
   });
 


### PR DESCRIPTION
Alternative to #118
Related to https://github.com/replicate/replicate-javascript/issues/76
Reverts https://github.com/replicate/replicate-javascript/pull/77

This PR updates the client constructor to not throw an error if the `auth` option isn't provided.

Unlike #118, this PR removes the check rather than deferring it to the time of request. I think the API should be responsible for communicating missing credentials with a 401. With #103, we should be set up to surfacing that error correctly.