### PR TITLE
options are optional in replicate.wait()

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class Replicate {
     // eslint-disable-next-line no-promise-executor-return
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    const interval = options.interval || 500;
+    const interval = options?.interval || 500;
 
     let updatedPrediction = await this.predictions.get(id);
 

--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class Replicate {
     // eslint-disable-next-line no-promise-executor-return
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    const interval = options?.interval || 500;
+    const interval = (options && options.interval) || 500;
 
     let updatedPrediction = await this.predictions.get(id);
 


### PR DESCRIPTION
Fixes an error where this code:

```js
  let prediction = await replicate.predictions.create({
      // zeke/nyu-llama-2-7b-chat-training-test
      version: 'aae0f2ef9dd402d20aba3e83adcbb7ab8fb55fdc3081d14abb6aa082b181c981',
      input: {
        prompt: 'mailbag ->',
        system_prompt: '',
      },
    }
  );
  console.log(prediction);
  prediction = await replicate.wait(prediction);
```

produces this error:

```
$ node test-llama.js
{
  id: 'rfxxkdtbnmvzpmol3lt4xidoti',
  version: 'aae0f2ef9dd402d20aba3e83adcbb7ab8fb55fdc3081d14abb6aa082b181c981',
  input: { prompt: 'mailbag ->', system_prompt: '' },
  logs: '',
  error: null,
  status: 'starting',
  created_at: '2023-08-15T16:23:50.344220582Z',
  urls: {
    cancel: 'https://api.replicate.com/v1/predictions/rfxxkdtbnmvzpmol3lt4xidoti/cancel',
    get: 'https://api.replicate.com/v1/predictions/rfxxkdtbnmvzpmol3lt4xidoti'
  }
}
/Users/z/Desktop/Replicate-Examples/node_modules/replicate/index.js:274
    const interval = options.interval || 500;
                             ^

TypeError: Cannot read properties of undefined (reading 'interval')
    at Replicate.wait (/Users/z/Desktop/Replicate-Examples/node_modules/replicate/index.js:274:30)
    at go (file:///Users/z/Desktop/Replicate-Examples/test-llama.js:22:32)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

and an empty options object circumvents the error:

```
prediction = await replicate.wait(prediction, {});
```