### PR TITLE
Validate `version` parameter in `predictions.create` method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'generator-star-spacing': 'off',
     'max-len': 'off',
     'operator-linebreak': 'off',
+    'object-curly-newline': 'off',
     'jsdoc/require-param-description': 'off',
     'jsdoc/tag-lines': ['error', 'any', { startLines: 1 }],
   },

--- a/index.test.ts
+++ b/index.test.ts
@@ -167,6 +167,17 @@ describe('Replicate client', () => {
       });
     });
 
+    test('Throws an error if version is invalid', async () => {
+      await expect(async () => {
+        await client.predictions.create({
+          version: 'owner/model:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa',
+          input: {
+            text: 'Alice',
+          },
+        });
+      }).rejects.toThrow('Invalid version');
+    });
+
     test('Throws an error if webhook URL is invalid', async () => {
       await expect(async () => {
         await client.predictions.create({

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -10,12 +10,16 @@
  * @returns {Promise<object>} Resolves with the created prediction
  */
 async function createPrediction(options) {
-  const { stream, ...data } = options;
+  const { version, stream, webhook, ...data } = options;
 
-  if (data.webhook) {
+  if (!version || /[^0-9a-f]/.test(version)) {
+    throw new Error('Invalid version');
+  }
+
+  if (webhook) {
     try {
       // eslint-disable-next-line no-new
-      new URL(data.webhook);
+      new URL(webhook);
     } catch (err) {
       throw new Error('Invalid webhook URL');
     }
@@ -23,7 +27,7 @@ async function createPrediction(options) {
 
   const response = await this.request('/predictions', {
     method: 'POST',
-    data: { ...data, stream },
+    data: { ...data, version, webhook, stream },
   });
 
   return response.json();


### PR DESCRIPTION
The `predictions.create` method takes a `version` parameter in the form of a 40-character hexadecimal string. By contrast, the `run` method takes a fully-qualified version identifier in the form `{owner}/{model}:{version}`.

This PR adds a check to prevent clients from accidentally sending the latter `{owner}/{model}:{version}` form as a `version` parameter.