### PR TITLE
Add `started_at` attribute to `Prediction` type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare module 'replicate' {
     webhook?: string;
     webhook_events_filter?: WebhookEventType[];
     created_at: string;
-    updated_at: string;
+    started_at?: string;
     completed_at?: string;
     urls: {
       get: string;


### PR DESCRIPTION
Resolves #128

This PR also removes a non-existent `updated_at` attribute from the type definition. See https://replicate.com/docs/reference/http#predictions.get