### PR TITLE
Make output type stricter and use unknown for error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,9 +41,9 @@ declare module 'replicate' {
     status: Status;
     version: string;
     input: object;
-    output?: any;
+    output?: string[];
     source: 'api' | 'web';
-    error?: any;
+    error?: unknown;
     logs?: string;
     metrics?: {
       predict_time?: number;


### PR DESCRIPTION
From my testing the output is always a string array, this just helps confirm that a bit.

I believe unknown is a better typing then error, this will force consumers to do more type checking then just accepting the any.