### PR TITLE
Fix fetch scoping for cloudflare workers

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,9 +211,10 @@ class Replicate {
     const shouldRetry = method === 'GET' ?
       (response) => (response.status === 429 || response.status >= 500) :
       (response) => (response.status === 429);
+
     // Workaround to fix `TypeError: Illegal invocation` error in Cloudflare Workers
     // https://github.com/replicate/replicate-javascript/issues/134
-    const _fetch = this.fetch;
+    const _fetch = this.fetch; // eslint-disable-line no-underscore-dangle
     const response = await withAutomaticRetries(async () => _fetch(url, init), { shouldRetry });
 
     if (!response.ok) {

--- a/index.js
+++ b/index.js
@@ -211,6 +211,8 @@ class Replicate {
     const shouldRetry = method === 'GET' ?
       (response) => (response.status === 429 || response.status >= 500) :
       (response) => (response.status === 429);
+    // Workaround to fix `TypeError: Illegal invocation` error in Cloudflare Workers
+    // https://github.com/replicate/replicate-javascript/issues/134
     const _fetch = this.fetch;
     const response = await withAutomaticRetries(async () => _fetch(url, init), { shouldRetry });
 

--- a/index.js
+++ b/index.js
@@ -211,7 +211,8 @@ class Replicate {
     const shouldRetry = method === 'GET' ?
       (response) => (response.status === 429 || response.status >= 500) :
       (response) => (response.status === 429);
-    const response = await withAutomaticRetries(async () => this.fetch(url, init), { shouldRetry });
+    const _fetch = this.fetch;
+    const response = await withAutomaticRetries(async () => _fetch(url, init), { shouldRetry });
 
     if (!response.ok) {
       const request = new Request(url, init);


### PR DESCRIPTION
I was having the same bug described in #134 and traced it to this line.

Still trying to wrap my head around why `this.fetch` cannot be invoked when the wrapping closure is called inside `withAutomaticRetries`. And why does this only happen in cloudflare workers? Saving the fetch method to a temporary variable seems to work though.

Fixes #134 