### PR TITLE
Require built-in `stream` module using explicit `node:stream` name

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,4 +1,4 @@
-const { Readable } = require("stream");
+const { Readable } = require("node:stream");
 
 /**
  * A server-sent event.


### PR DESCRIPTION
Follow-up to #169 