### PR TITLE
Fix conditional import / export of streaming functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const ApiError = require("./lib/error");
 const ModelVersionIdentifier = require("./lib/identifier");
-const { Stream } = require("./lib/stream");
+const { createStream } = require("./lib/stream");
 const { withAutomaticRetries } = require("./lib/util");
 
 const collections = require("./lib/collections");
@@ -270,7 +270,7 @@ class Replicate {
 
     if (prediction.urls && prediction.urls.stream) {
       const { signal } = options;
-      const stream = new Stream(prediction.urls.stream, { signal });
+      const stream = createStream(prediction.urls.stream, { signal });
       yield* stream;
     } else {
       throw new Error("Prediction does not support streaming");

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -38,7 +38,7 @@ async function createStream(url, options) {
     );
   } catch (e) {
     try {
-      Readable = await import("stream").then((module) => module.Readable);
+      Readable = await import("node:stream").then((module) => module.Readable);
     } catch (e) {
       throw new Error(
         "Readable streams are not supported. Please use Node.js 18 or later, or install the readable-stream package."

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,15 +1,3 @@
-// Attempt to use readable-stream if available, attempt to use the built-in stream module.
-let Readable;
-try {
-  Readable = require("readable-stream").Readable;
-} catch (e) {
-  try {
-    Readable = require("stream").Readable;
-  } catch (e) {
-    Readable = null;
-  }
-}
-
 /**
  * A server-sent event.
  */
@@ -41,99 +29,119 @@ class ServerSentEvent {
   }
 }
 
-/**
- * A stream of server-sent events.
- */
-class Stream extends Readable {
-  /**
-   * Create a new stream of server-sent events.
-   *
-   * @param {string} url The URL to connect to.
-   * @param {object} options The fetch options.
-   */
-  constructor(url, options) {
-    if (!Readable) {
+async function createStream(url, options) {
+  // Attempt to use readable-stream if available, attempt to use the built-in stream module.
+  let Readable;
+  try {
+    Readable = await import("readable-stream").then(
+      (module) => module.Readable
+    );
+  } catch (e) {
+    try {
+      Readable = await import("stream").then((module) => module.Readable);
+    } catch (e) {
       throw new Error(
         "Readable streams are not supported. Please use Node.js 18 or later, or install the readable-stream package."
       );
     }
-
-    super();
-    this.url = url;
-    this.options = options;
-
-    this.event = null;
-    this.data = [];
-    this.lastEventId = null;
-    this.retry = null;
   }
 
-  decode(line) {
-    if (!line) {
-      if (!this.event && !this.data.length && !this.lastEventId) {
-        return null;
+  /**
+   * A stream of server-sent events.
+   */
+  class Stream extends Readable {
+    /**
+     * Create a new stream of server-sent events.
+     *
+     * @param {string} url The URL to connect to.
+     * @param {object} options The fetch options.
+     */
+    constructor(url, options) {
+      if (!Readable) {
+        throw new Error(
+          "Readable streams are not supported. Please use Node.js 18 or later, or install the readable-stream package."
+        );
       }
 
-      const sse = new ServerSentEvent(
-        this.event,
-        this.data.join("\n"),
-        this.lastEventId
-      );
+      super();
+      this.url = url;
+      this.options = options;
 
       this.event = null;
       this.data = [];
+      this.lastEventId = null;
       this.retry = null;
-
-      return sse;
     }
 
-    if (line.startsWith(":")) {
+    decode(line) {
+      if (!line) {
+        if (!this.event && !this.data.length && !this.lastEventId) {
+          return null;
+        }
+
+        const sse = new ServerSentEvent(
+          this.event,
+          this.data.join("\n"),
+          this.lastEventId
+        );
+
+        this.event = null;
+        this.data = [];
+        this.retry = null;
+
+        return sse;
+      }
+
+      if (line.startsWith(":")) {
+        return null;
+      }
+
+      const [field, value] = line.split(": ");
+      if (field === "event") {
+        this.event = value;
+      } else if (field === "data") {
+        this.data.push(value);
+      } else if (field === "id") {
+        this.lastEventId = value;
+      }
+
       return null;
     }
 
-    const [field, value] = line.split(": ");
-    if (field === "event") {
-      this.event = value;
-    } else if (field === "data") {
-      this.data.push(value);
-    } else if (field === "id") {
-      this.lastEventId = value;
-    }
+    async *[Symbol.asyncIterator]() {
+      const response = await fetch(this.url, {
+        ...this.options,
+        headers: {
+          Accept: "text/event-stream",
+        },
+      });
 
-    return null;
-  }
+      for await (const chunk of response.body) {
+        const decoder = new TextDecoder("utf-8");
+        const text = decoder.decode(chunk);
+        const lines = text.split("\n");
+        for (const line of lines) {
+          const sse = this.decode(line);
+          if (sse) {
+            if (sse.event === "error") {
+              throw new Error(sse.data);
+            }
 
-  async *[Symbol.asyncIterator]() {
-    const response = await fetch(this.url, {
-      ...this.options,
-      headers: {
-        Accept: "text/event-stream",
-      },
-    });
+            yield sse;
 
-    for await (const chunk of response.body) {
-      const decoder = new TextDecoder("utf-8");
-      const text = decoder.decode(chunk);
-      const lines = text.split("\n");
-      for (const line of lines) {
-        const sse = this.decode(line);
-        if (sse) {
-          if (sse.event === "error") {
-            throw new Error(sse.data);
-          }
-
-          yield sse;
-
-          if (sse.event === "done") {
-            return;
+            if (sse.event === "done") {
+              return;
+            }
           }
         }
       }
     }
   }
+
+  return new Stream(url, options);
 }
 
 module.exports = {
-  Stream,
   ServerSentEvent,
+  createStream,
 };


### PR DESCRIPTION
Resolves #179 

The `stream` method introduced by #169 requires a readable stream interface. #172 introduced a conditional import, whereby the library attempts to load the built-in `stream` module and attempts to fall back on the `readable-stream` polyfill. However, something about that seems to confuse Next.js (during tree-shaking?), causing it to report an import error in stream when tracing unrelated errors.

This PR refactors this in the following ways:

- Use `import` instead of `require`
- Export `createStream` instead of `Stream` class; the function can `throw` if `Readable` isn't found
- Import `node:stream` instead of `stream` to help distinguish use of core module (this was [introduced in Node.js 14](https://nodejs.org/api/modules.html#core-modules))

