### PR TITLE
Encourage passing `fetch` option rather than patching the instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ import fetch from "cross-fetch";
 const replicate = new Replicate({ fetch });
 ```
 
-You can override the `fetch` property to add custom behavior to client requests,
+You can also use the `fetch` option to add custom behavior to client requests,
 such as injecting headers or adding log statements.
 
 ```js
-replicate.fetch = (url, options) => {
+const customFetch = (url, options) => {
   const headers = options && options.headers ? { ...options.headers } : {};
   headers["X-Custom-Header"] = "some value";
 
@@ -139,6 +139,8 @@ replicate.fetch = (url, options) => {
 
   return fetch(url, { ...options, headers });
 };
+
+const replicate = new Replicate({ fetch: customFetch });
 ```
 
 ### `replicate.run`


### PR DESCRIPTION
Minor stylistic change, but means that we're not committing to a `replicate.fetch` top level function and instead encouraging any custom functionality to be passed to the constructor rather than monkey patching the api.