### PR TITLE
Add support for files API endpoints

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.0.0/schema.json",
   "files": {
-    "ignore": [".wrangler", "vendor/*"]
+    "ignore": [
+      ".wrangler",
+      "node_modules",
+      "vendor/*"
+    ]
   },
   "formatter": {
     "indentStyle": "space",

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ declare module "replicate" {
     size: number;
     etag: string;
     checksum: string;
-    metadata: Record<string, any>;
+    metadata: Record<string, unknown>;
     created_at: string;
     expires_at: string | null;
     urls: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,21 @@ declare module "replicate" {
     };
   }
 
+  export interface FileObject {
+    id: string;
+    name: string;
+    content_type: string;
+    size: number;
+    etag: string;
+    checksum: string;
+    metadata: Record<string, any>;
+    created_at: string;
+    expires_at: string | null;
+    urls: {
+      get: string;
+    };
+  }
+
   export interface Hardware {
     sku: string;
     name: string;
@@ -119,12 +134,16 @@ declare module "replicate" {
         input: Request | string,
         init?: RequestInit
       ) => Promise<Response>;
+      prepareInputs?: (
+        input: Record<string, any>
+      ) => Promise<Record<string, any>>;
     });
 
     auth: string;
     userAgent?: string;
     baseUrl?: string;
     fetch: (input: Request | string, init?: RequestInit) => Promise<Response>;
+    prepareInputs: (input: Record<string, any>) => Promise<Record<string, any>>;
 
     run(
       identifier: `${string}/${string}` | `${string}/${string}:${string}`,
@@ -220,6 +239,16 @@ declare module "replicate" {
       list(): Promise<Page<Deployment>>;
     };
 
+    files: {
+      create: (
+        file: File | Blob,
+        metadata?: Record<string, string | number | boolean | null>
+      ) => Promise<FileObject>;
+      list: () => Promise<FileObject>;
+      get: (file_id: string) => Promise<FileObject>;
+      delete: (file_id: string) => Promise<FileObject>;
+    };
+
     hardware: {
       list(): Promise<Hardware[]>;
     };
@@ -310,4 +339,9 @@ declare module "replicate" {
     current: number;
     total: number;
   } | null;
+
+  export function transformFileInputs(
+    inputs: Record<string, any>,
+    options: { fallbackToDataURI: boolean }
+  ): Promise<Record<string, any>>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,8 @@ declare module "replicate" {
 
   export type Training = Prediction;
 
+  export type FileEncodingStrategy = "default" | "upload" | "data-uri";
+
   export interface Page<T> {
     previous?: string;
     next?: string;
@@ -134,16 +136,14 @@ declare module "replicate" {
         input: Request | string,
         init?: RequestInit
       ) => Promise<Response>;
-      prepareInputs?: (
-        input: Record<string, any>
-      ) => Promise<Record<string, any>>;
+      fileEncodingStrategy?: FileEncodingStrategy;
     });
 
     auth: string;
     userAgent?: string;
     baseUrl?: string;
     fetch: (input: Request | string, init?: RequestInit) => Promise<Response>;
-    prepareInputs: (input: Record<string, any>) => Promise<Record<string, any>>;
+    fileEncodingStrategy: FileEncodingStrategy;
 
     run(
       identifier: `${string}/${string}` | `${string}/${string}:${string}`,
@@ -339,9 +339,4 @@ declare module "replicate" {
     current: number;
     total: number;
   } | null;
-
-  export function transformFileInputs(
-    inputs: Record<string, any>,
-    options: { fallbackToDataURI: boolean }
-  ): Promise<Record<string, any>>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -239,16 +239,6 @@ declare module "replicate" {
       list(): Promise<Page<Deployment>>;
     };
 
-    files: {
-      create: (
-        file: File | Blob,
-        metadata?: Record<string, string | number | boolean | null>
-      ) => Promise<FileObject>;
-      list: () => Promise<FileObject>;
-      get: (file_id: string) => Promise<FileObject>;
-      delete: (file_id: string) => Promise<FileObject>;
-    };
-
     hardware: {
       list(): Promise<Hardware[]>;
     };

--- a/index.js
+++ b/index.js
@@ -6,14 +6,11 @@ const {
   validateWebhook,
   parseProgressFromLogs,
   streamAsyncIterator,
-  transformFileInputsToReplicateFileURLs,
-  transformFileInputsToBase64EncodedDataURIs,
 } = require("./lib/util");
 
 const accounts = require("./lib/accounts");
 const collections = require("./lib/collections");
 const deployments = require("./lib/deployments");
-const files = require("./lib/files");
 const hardware = require("./lib/hardware");
 const models = require("./lib/models");
 const predictions = require("./lib/predictions");
@@ -78,13 +75,6 @@ class Replicate {
       predictions: {
         create: deployments.predictions.create.bind(this),
       },
-    };
-
-    this.files = {
-      create: files.create.bind(this),
-      list: files.list.bind(this),
-      get: files.get.bind(this),
-      delete: files.delete.bind(this),
     };
 
     this.hardware = {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ class Replicate {
    * @param {string} options.userAgent - Identifier of your app
    * @param {string} [options.baseUrl] - Defaults to https://api.replicate.com/v1
    * @param {Function} [options.fetch] - Fetch function to use. Defaults to `globalThis.fetch`
-   * @param {Function} [options.prepareInput] - Function to prepare input data before sending it to the API.
+   * @param {"default" | "upload" | "data-uri"} [options.fileEncodingStrategy] - Determines the file encoding strategy to use
    */
   constructor(options = {}) {
     this.auth =
@@ -59,15 +59,7 @@ class Replicate {
       options.userAgent || `replicate-javascript/${packageJSON.version}`;
     this.baseUrl = options.baseUrl || "https://api.replicate.com/v1";
     this.fetch = options.fetch || globalThis.fetch;
-    this.prepareInputs =
-      options.prepareInputs ||
-      (async (inputs) => {
-        try {
-          return await transformFileInputsToReplicateFileURLs(this, inputs);
-        } catch (error) {
-          return await transformFileInputsToBase64EncodedDataURIs(inputs);
-        }
-      });
+    this.fileEncodingStrategy = options.fileEncodingStrategy ?? "default";
 
     this.accounts = {
       current: accounts.current.bind(this),

--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -1,3 +1,5 @@
+const { transformFileInputs } = require("./util");
+
 /**
  * Create a new prediction with a deployment
  *
@@ -28,7 +30,11 @@ async function createPrediction(deployment_owner, deployment_name, options) {
       method: "POST",
       data: {
         ...data,
-        input: await this.prepareInputs(input),
+        input: await transformFileInputs(
+          this,
+          input,
+          this.fileEncodingStrategy
+        ),
         stream,
       },
     }

--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -1,5 +1,3 @@
-const { transformFileInputs } = require("./util");
-
 /**
  * Create a new prediction with a deployment
  *
@@ -30,7 +28,7 @@ async function createPrediction(deployment_owner, deployment_name, options) {
       method: "POST",
       data: {
         ...data,
-        input: await transformFileInputs(input),
+        input: await this.prepareInputs(input),
         stream,
       },
     }

--- a/lib/files.js
+++ b/lib/files.js
@@ -11,13 +11,13 @@ async function createFile(file, metadata = {}) {
   let filename;
   let blob;
   if (file instanceof Blob) {
-    fileName = file.name || `blob_${Date.now()}`;
+    filename = file.name || `blob_${Date.now()}`;
     blob = file;
   } else if (Buffer.isBuffer(file)) {
-    fileName = `buffer_${Date.now()}`;
+    filename = `buffer_${Date.now()}`;
     blob = new Blob(file, { type: "application/octet-stream" });
   } else {
-    throw new Error("Invalid file argument, must be a Blob or File");
+    throw new Error("Invalid file argument, must be a Blob, File or Buffer");
   }
 
   form.append("content", blob, filename);

--- a/lib/files.js
+++ b/lib/files.js
@@ -1,0 +1,86 @@
+/**
+ * Create a file
+ *
+ * @param {object} file - Required. The file object.
+ * @param {object} metadata - Optional. User-provided metadata associated with the file.
+ * @returns {Promise<object>} - Resolves with the file data
+ */
+async function createFile(file, metadata = {}) {
+  const form = new FormData();
+
+  let filename;
+  let blob;
+  if (file instanceof Blob) {
+    fileName = file.name || `blob_${Date.now()}`;
+    blob = file;
+  } else if (Buffer.isBuffer(file)) {
+    fileName = `buffer_${Date.now()}`;
+    blob = new Blob(file, { type: "application/octet-stream" });
+  } else {
+    throw new Error("Invalid file argument, must be a Blob or File");
+  }
+
+  form.append("content", blob, filename);
+  form.append(
+    "metadata",
+    new Blob([JSON.stringify(metadata)], { type: "application/json" })
+  );
+
+  const response = await this.request("/files", {
+    method: "POST",
+    data: form,
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response.json();
+}
+
+/**
+ * List all files
+ *
+ * @returns {Promise<object>} - Resolves with the files data
+ */
+async function listFiles() {
+  const response = await this.request("/files", {
+    method: "GET",
+  });
+
+  return response.json();
+}
+
+/**
+ * Get a file
+ *
+ * @param {string} file_id - Required. The ID of the file.
+ * @returns {Promise<object>} - Resolves with the file data
+ */
+async function getFile(file_id) {
+  const response = await this.request(`/files/${file_id}`, {
+    method: "GET",
+  });
+
+  return response.json();
+}
+
+/**
+ * Delete a file
+ *
+ * @param {string} file_id - Required. The ID of the file.
+ * @returns {Promise<object>} - Resolves with the deletion confirmation
+ */
+async function deleteFile(file_id) {
+  const response = await this.request(`/files/${file_id}`, {
+    method: "DELETE",
+  });
+
+  return response.json();
+}
+
+module.exports = {
+  create: createFile,
+  list: listFiles,
+  get: getFile,
+  delete: deleteFile,
+};

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -1,3 +1,5 @@
+const { transformFileInputs } = require("./util");
+
 /**
  * Create a new prediction
  *
@@ -28,7 +30,11 @@ async function createPrediction(options) {
       method: "POST",
       data: {
         ...data,
-        input: await this.prepareInputs(input),
+        input: await transformFileInputs(
+          this,
+          input,
+          this.fileEncodingStrategy
+        ),
         version,
         stream,
       },
@@ -38,7 +44,11 @@ async function createPrediction(options) {
       method: "POST",
       data: {
         ...data,
-        input: await this.prepareInputs(input),
+        input: await transformFileInputs(
+          this,
+          input,
+          this.fileEncodingStrategy
+        ),
         stream,
       },
     });

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -1,5 +1,3 @@
-const { transformFileInputs } = require("./util");
-
 /**
  * Create a new prediction
  *
@@ -30,7 +28,7 @@ async function createPrediction(options) {
       method: "POST",
       data: {
         ...data,
-        input: await transformFileInputs(input),
+        input: await this.prepareInputs(input),
         version,
         stream,
       },
@@ -40,7 +38,7 @@ async function createPrediction(options) {
       method: "POST",
       data: {
         ...data,
-        input: await transformFileInputs(input),
+        input: await this.prepareInputs(input),
         stream,
       },
     });

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,5 @@
 const ApiError = require("./error");
+const { create: createFile } = require("./files");
 
 /**
  * @see {@link validateWebhook}
@@ -253,7 +254,7 @@ async function transformFileInputs(client, inputs, strategy) {
 async function transformFileInputsToReplicateFileURLs(client, inputs) {
   return await transform(inputs, async (value) => {
     if (value instanceof Blob || value instanceof Buffer) {
-      const file = await client.files.create(value);
+      const file = await createFile.call(client, value);
       return file.urls.get;
     }
 
@@ -438,6 +439,4 @@ module.exports = {
   withAutomaticRetries,
   parseProgressFromLogs,
   streamAsyncIterator,
-  transformFileInputsToBase64EncodedDataURIs,
-  transformFileInputsToReplicateFileURLs,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -215,6 +215,26 @@ async function withAutomaticRetries(request, options = {}) {
   return request();
 }
 
+/**
+ * Walks the inputs and, for any File or Blob, tries to upload it to Replicate
+ * and replaces the input with the URL of the uploaded file.
+ *
+ * @param {Replicate} client - The client used to upload the file
+ * @param {object} inputs - The inputs to transform
+ * @returns {object} - The transformed inputs
+ * @throws {ApiError} If the request to upload the file fails
+ */
+async function transformFileInputsToReplicateFileURLs(client, inputs) {
+  return await transform(inputs, async (value) => {
+    if (value instanceof Blob || value instanceof Buffer) {
+      const file = await client.files.create(value);
+      return file.urls.get;
+    }
+
+    return value;
+  });
+}
+
 const MAX_DATA_URI_SIZE = 10_000_000;
 
 /**
@@ -225,9 +245,9 @@ const MAX_DATA_URI_SIZE = 10_000_000;
  * @returns {object} - The transformed inputs
  * @throws {Error} If the size of inputs exceeds a given threshould set by MAX_DATA_URI_SIZE
  */
-async function transformFileInputs(inputs) {
+async function transformFileInputsToBase64EncodedDataURIs(inputs) {
   let totalBytes = 0;
-  const result = await transform(inputs, async (value) => {
+  return await transform(inputs, async (value) => {
     let buffer;
     let mime;
 
@@ -258,8 +278,6 @@ async function transformFileInputs(inputs) {
 
     return `data:${mime};base64,${data}`;
   });
-
-  return result;
 }
 
 // Walk a JavaScript object and transform the leaf values.
@@ -394,4 +412,6 @@ module.exports = {
   withAutomaticRetries,
   parseProgressFromLogs,
   streamAsyncIterator,
+  transformFileInputsToBase64EncodedDataURIs,
+  transformFileInputsToReplicateFileURLs,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -209,10 +209,36 @@ async function withAutomaticRetries(request, options = {}) {
       }
       attempts += 1;
     }
-    /* eslint-enable no-await-in-loop */
   } while (attempts < maxRetries);
 
   return request();
+}
+
+/**
+ * Walks the inputs and, for any File or Blob, tries to upload it to Replicate
+ * and replaces the input with the URL of the uploaded file.
+ *
+ * @param {Replicate} client - The client used to upload the file
+ * @param {object} inputs - The inputs to transform
+ * @param {"default" | "upload" | "data-uri"} strategy - Whether to upload files to Replicate, encode as dataURIs or try both.
+ * @returns {object} - The transformed inputs
+ * @throws {ApiError} If the request to upload the file fails
+ */
+async function transformFileInputs(client, inputs, strategy) {
+  switch (strategy) {
+    case "data-uri":
+      return await transformFileInputsToBase64EncodedDataURIs(client, inputs);
+    case "upload":
+      return await transformFileInputsToReplicateFileURLs(client, inputs);
+    case "default":
+      try {
+        return await transformFileInputsToReplicateFileURLs(client, inputs);
+      } catch (error) {
+        return await transformFileInputsToBase64EncodedDataURIs(inputs);
+      }
+    default:
+      throw new Error(`Unexpected file upload strategy: ${strategy}`);
+  }
 }
 
 /**


### PR DESCRIPTION
In https://github.com/replicate/replicate-javascript/pull/198, we added support for automatically encoding binary prediction inputs as base64-encoded data URIs.

This PR adds support for the new (write-only) files API. By default, each binary input is uploaded and replaced with a URL to the created file. Before the inputs are sent to the model to be run, Replicate's API rewrites the URL to make the file downloadable.

From the perspective of the caller, the out-of-the-box experience is the same: You pass a file handle or blog as an input, and that's it — everything just works. And with the files API, things work much better for larger files, whose data URI encoding can cause write timeouts and other problems.

What I'm less clear about is how to customize this behavior. My current solution is two-fold: 

- Add a `prepareInputs` property to the client
- Export the `transformFileInputsToBase64EncodedDataURIs` and `transformFileInputsToReplicateFileURLs` helper functions

By default, `prepareInputs` tries to upload files and falls back to data URI encoding (for example if the files API is unavailable for some reason). 

```js
this.prepareInputs =
  options.prepareInputs ||
  (async (inputs) => {
    try {
      return await transformFileInputsToReplicateFileURLs(this, inputs);
    } catch (error) {
      return await transformFileInputsToBase64EncodedDataURIs(inputs);
    }
  });
```

Users can override this to customize the behavior however they like. For example, they could only base64-encode inputs, conditionalize based on file size / content, or throw an error.

I'm pretty sure we need it to be this flexible. But is it too clunky? Would love to hear your thoughts, @aron @zeke.