### PR TITLE
Integration tests for common runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,26 @@ jobs:
       - run: npm run test
       - run: npm run check
       - run: npm run lint
+
+  integration:
+    needs: test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+        suite: [commonjs, esm, typescript]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
+
+    env:
+      REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm --prefix integration/${{ matrix.suite }} ci --omit=dev
+      - run: npm --prefix integration/${{ matrix.suite }} test

--- a/integration/commonjs/index.js
+++ b/integration/commonjs/index.js
@@ -1,0 +1,16 @@
+const Replicate = require("replicate");
+
+const replicate = new Replicate({
+  auth: process.env.REPLICATE_API_TOKEN,
+});
+
+module.exports = async function main() {
+  return await replicate.run(
+    "replicate/hello-world:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+    {
+      input: {
+        text: "Alice"
+      }
+    }
+  );
+};

--- a/integration/commonjs/index.js
+++ b/integration/commonjs/index.js
@@ -9,7 +9,7 @@ module.exports = async function main() {
     "replicate/hello-world:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
     {
       input: {
-        text: "Alice"
+        text: "Claire CommonJS"
       }
     }
   );

--- a/integration/commonjs/index.test.js
+++ b/integration/commonjs/index.test.js
@@ -1,0 +1,8 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const main = require('./index');
+
+test('main', async () => {
+  const output = await main();
+  assert.equal(output, "hello Alice");
+});

--- a/integration/commonjs/index.test.js
+++ b/integration/commonjs/index.test.js
@@ -4,5 +4,5 @@ const main = require('./index');
 
 test('main', async () => {
   const output = await main();
-  assert.equal(output, "hello Alice");
+  assert.equal(output, "hello Claire CommonJS");
 });

--- a/integration/commonjs/package-lock.json
+++ b/integration/commonjs/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "replicate-app-commonjs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "replicate-app-commonjs",
+      "version": "0.0.0",
+      "dependencies": {
+        "replicate": "file:../../"
+      }
+    },
+    "../..": {
+      "version": "0.25.2",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@biomejs/biome": "^1.4.1",
+        "@types/jest": "^29.5.3",
+        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "cross-fetch": "^3.1.5",
+        "jest": "^29.6.2",
+        "nock": "^13.3.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.0.2"
+      },
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      },
+      "optionalDependencies": {
+        "readable-stream": ">=4.0.0"
+      }
+    },
+    "node_modules/replicate": {
+      "resolved": "../..",
+      "link": true
+    }
+  }
+}

--- a/integration/commonjs/package.json
+++ b/integration/commonjs/package.json
@@ -2,7 +2,7 @@
   "name": "replicate-app-commonjs",
   "version": "0.0.0",
   "private": true,
-  "description": "",
+  "description": "CommonJS integration tests",
   "main": "index.js",
   "scripts": {
     "test": "node --test ./index.test.js"

--- a/integration/commonjs/package.json
+++ b/integration/commonjs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "replicate-app-commonjs",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test ./index.test.js"
+  },
+  "dependencies": {
+    "replicate": "file:../../"
+  }
+}

--- a/integration/esm/index.js
+++ b/integration/esm/index.js
@@ -1,0 +1,16 @@
+import Replicate from "replicate";
+
+const replicate = new Replicate({
+  auth: process.env.REPLICATE_API_TOKEN,
+});
+
+export default async function main() {
+  return await replicate.run(
+    "replicate/hello-world:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+    {
+      input: {
+        text: "Alice"
+      }
+    }
+  );
+};

--- a/integration/esm/index.js
+++ b/integration/esm/index.js
@@ -9,7 +9,7 @@ export default async function main() {
     "replicate/hello-world:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
     {
       input: {
-        text: "Alice"
+        text: "Evelyn ESM"
       }
     }
   );

--- a/integration/esm/index.test.js
+++ b/integration/esm/index.test.js
@@ -4,5 +4,5 @@ import main from './index.js';
 
 test('main', async () => {
   const output = await main();
-  assert.equal(output, "hello Alice");
+  assert.equal(output, "hello Evelyn ESM");
 });

--- a/integration/esm/index.test.js
+++ b/integration/esm/index.test.js
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import main from './index.js';
+
+test('main', async () => {
+  const output = await main();
+  assert.equal(output, "hello Alice");
+});

--- a/integration/esm/package-lock.json
+++ b/integration/esm/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "replicate-app-esm",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "replicate-app-esm",
+      "version": "0.0.0",
+      "dependencies": {
+        "replicate": "file:../../"
+      }
+    },
+    "../..": {
+      "name": "replicate",
+      "version": "0.25.2",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@biomejs/biome": "^1.4.1",
+        "@types/jest": "^29.5.3",
+        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "cross-fetch": "^3.1.5",
+        "jest": "^29.6.2",
+        "nock": "^13.3.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.0.2"
+      },
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      },
+      "optionalDependencies": {
+        "readable-stream": ">=4.0.0"
+      }
+    },
+    "node_modules/replicate": {
+      "resolved": "../..",
+      "link": true
+    }
+  }
+}

--- a/integration/esm/package.json
+++ b/integration/esm/package.json
@@ -2,7 +2,7 @@
   "name": "replicate-app-esm",
   "version": "0.0.0",
   "private": true,
-  "description": "",
+  "description": "ESM (ECMAScript Modules) integration tests",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/integration/esm/package.json
+++ b/integration/esm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "replicate-app-esm",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "node --test ./index.test.js"
+  },
+  "dependencies": {
+    "replicate": "file:../../"
+  }
+}

--- a/integration/typescript/index.test.ts
+++ b/integration/typescript/index.test.ts
@@ -20,5 +20,5 @@ import type {
 
 test('main', async () => {
   const output = await main();
-  assert.equal(output, "hello Alice");
+  assert.equal(output, "hello Tracy TypeScript");
 });   

--- a/integration/typescript/index.test.ts
+++ b/integration/typescript/index.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import main from './index.js';
+
+// Verify exported types.
+import type { 
+  Status,
+  Visibility,
+  WebhookEventType,
+  ApiError,
+  Collection,
+  Hardware,
+  Model,
+  ModelVersion,
+  Prediction,
+  Training,
+  Page,
+  ServerSentEvent,
+} from "replicate";
+
+test('main', async () => {
+  const output = await main();
+  assert.equal(output, "hello Alice");
+});   

--- a/integration/typescript/index.ts
+++ b/integration/typescript/index.ts
@@ -1,0 +1,16 @@
+import Replicate from "replicate";
+
+const replicate = new Replicate({
+  auth: process.env.REPLICATE_API_TOKEN,
+});
+
+export default async function main() {
+  return await replicate.run(
+    "replicate/hello-world:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+    {
+      input: {
+        text: "Alice"
+      }
+    }
+  );
+};

--- a/integration/typescript/index.ts
+++ b/integration/typescript/index.ts
@@ -9,7 +9,7 @@ export default async function main() {
     "replicate/hello-world:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
     {
       input: {
-        text: "Alice"
+        text: "Tracy TypeScript"
       }
     }
   );

--- a/integration/typescript/package-lock.json
+++ b/integration/typescript/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "replicate-app-esm",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "replicate-app-esm",
+      "version": "0.0.0",
+      "dependencies": {
+        "@types/node": "^20.11.0",
+        "replicate": "file:../../",
+        "typescript": "^5.3.3"
+      }
+    },
+    "../..": {
+      "name": "replicate",
+      "version": "0.25.2",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@biomejs/biome": "^1.4.1",
+        "@types/jest": "^29.5.3",
+        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "cross-fetch": "^3.1.5",
+        "jest": "^29.6.2",
+        "nock": "^13.3.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.0.2"
+      },
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      },
+      "optionalDependencies": {
+        "readable-stream": ">=4.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/replicate": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    }
+  }
+}

--- a/integration/typescript/package.json
+++ b/integration/typescript/package.json
@@ -2,7 +2,7 @@
   "name": "replicate-app-typescript",
   "version": "0.0.0",
   "private": true,
-  "description": "",
+  "description": "TypeScript integration tests",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/integration/typescript/package.json
+++ b/integration/typescript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "replicate-app-typescript",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "tsc && node --test ./dist/index.test.js"
+  },
+  "dependencies": {
+    "@types/node": "^20.11.0",
+    "replicate": "file:../../",
+    "typescript": "^5.3.3"
+  }
+}

--- a/integration/typescript/tsconfig.json
+++ b/integration/typescript/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2018",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "nodenext",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "inlineSourceMap": true,                             /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,                            /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    "skipDefaultLibCheck": true,                         /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testPathIgnorePatterns: ["integration"],
   transform: {
     "^.+\\.ts?$": [
       "ts-jest",


### PR DESCRIPTION
I'm currently in the process of spending some spare time improving the structure of this repository. Ideally I want us to get to the point where we have three things:

1. a native esm friendly version of the repository (not just relying on the nodejs dual module system)
2. the `index.d.ts` generated automatically using `tsc --emitDeclarationOnly`.
3. a singleton instance of `Replicate` as the default export for the package so our examples can be as simple as:

    ```js
    const replicate = require("replicate");
    replicate.run(...);
    ``` 

    I'll follow up on this one in a second PR with more details and we'll still retain the constructor as a way of customizing the library.

This commit adds some basic integration tests and a new ci workflow for our three common runtimes, nodejs with commonjs and esm as well as TypeScript. The aim here is to ensure that the interface is consistent even if we refactor/restructure the package.

The change does require a `REPLICATE_API_TOKEN` to be available in the CI environment which I've added.