### PR TITLE
Specify `type` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "bugs": "https://github.com/replicate/replicate-javascript/issues",
   "license": "Apache-2.0",
   "main": "index.js",
+  "type": "commonjs",
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=7.19.0",


### PR DESCRIPTION
Related to #191 

From [publint.dev](https://publint.dev/rules#use_type)

> Since [Node.js v20.10.0](https://nodejs.org/en/blog/release/v20.10.0), it introduces a new `--experimental-default-type` flag to flip the default module system from "CJS-as-default" to "ESM-as-default". If enabled, `package.json` without the "type" field will mean its descendant JS files to be interpreted as ESM instead of CJS, which may not work correctly.
>
> While this only applies to files outside of `node_modules`, it's still recommended to set it up for future-proofing. And it also helps the `--experimental-detect-module` flag if enabled.
>
> Hence, if you've not set the `"type"` field, you can explictly set it as `"type": "commonjs"` (default value), or migrate to `"type": "module"` and write in ESM completely if possible.