### PR TITLE
Fix streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ const output = [];
 
 for await (const event of replicate.stream(model, options)) {
   console.debug({ event });
-  if (event && event === "output") {
+  if (event && event.event === "output") {
     output.push(event.data);
   }
 }

--- a/README.md
+++ b/README.md
@@ -223,7 +223,6 @@ const options = {
 const output = [];
 
 for await (const { event, data } of replicate.stream(model, options)) {
-  console.debug({ event });
   if (event === "output") {
     output.push(data);
   }

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ const output = [];
 
 for await (const { event, data } of replicate.stream(model, options)) {
   console.debug({ event });
-  if (event && event.event === "output") {
-    output.push(event.data);
+  if (event === "output") {
+    output.push(data);
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ const options = {
 };
 const output = [];
 
-for await (const event of replicate.stream(model, options)) {
+for await (const { event, data } of replicate.stream(model, options)) {
   console.debug({ event });
   if (event && event.event === "output") {
     output.push(event.data);


### PR DESCRIPTION
The example to use replicate.stream was wrongly checking the event type and was not producing any output. I adjusted the example so that it works. The `event &&` in front of the `event.event === 'output'` check seems unnecessary as I can't think of a scenario where `event` would be false-y and even `event.event` seems to always be of type string but I left it for now in case I'm missing something.