### PR TITLE
Fix stream() support for chunked event streams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -279,7 +279,7 @@ declare module "replicate" {
           signature?: string;
         },
     secret: string
-  ): boolean;
+  ): Promise<boolean>;
 
   export function parseProgressFromLogs(logs: Prediction | string): {
     percentage: number;

--- a/index.js
+++ b/index.js
@@ -289,7 +289,11 @@ class Replicate {
 
     if (prediction.urls && prediction.urls.stream) {
       const { signal } = options;
-      const stream = new Stream(prediction.urls.stream, { signal });
+      const stream = new Stream({
+        url: prediction.urls.stream,
+        fetch: this.fetch,
+        options: { signal },
+      });
       yield* stream;
     } else {
       throw new Error("Prediction does not support streaming");

--- a/index.test.ts
+++ b/index.test.ts
@@ -1179,7 +1179,7 @@ describe("Replicate client", () => {
       // This is a test secret and should not be used in production
       const secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
 
-      const isValid = validateWebhook(request, secret);
+      const isValid = await validateWebhook(request, secret);
       expect(isValid).toBe(true);
     });
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,4 +1,7 @@
 // Attempt to use readable-stream if available, attempt to use the built-in stream module.
+
+const ApiError = require("./error");
+
 let Readable;
 try {
   Readable = require("readable-stream").Readable;
@@ -107,15 +110,23 @@ class Stream extends Readable {
   }
 
   async *[Symbol.asyncIterator]() {
-    const response = await this.fetch(this.url, {
+    const init = {
       ...this.options,
       headers: {
         Accept: "text/event-stream",
       },
-    });
+    };
+    const response = await this.fetch(this.url, init);
 
     if (!response.ok) {
-      throw new Error();
+      // The cross-fetch shim doesn't accept Request objects so we create one here.
+      const request = new Request(this.url, init);
+      const text = await response.text();
+      throw new ApiError(
+        `Request to ${request.url} failed with status ${response.status} ${response.statusText}: ${text}.`,
+        request,
+        response
+      );
     }
 
     let partialChunk = "";

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -50,7 +50,7 @@ class Stream extends Readable {
    *
    * @param {object} config
    * @param {string} config.url The URL to connect to.
-   * @param {Function} [config.fetch] The fetch implemention to use.
+   * @param {typeof fetch} [config.fetch] The fetch implementation to use.
    * @param {object} [config.options] The fetch options.
    */
   constructor({ url, fetch = globalThis.fetch, options = {} }) {
@@ -114,10 +114,21 @@ class Stream extends Readable {
       },
     });
 
+    if (!response.ok) {
+      throw new Error();
+    }
+
+    let partialChunk = "";
     for await (const chunk of response.body) {
       const decoder = new TextDecoder("utf-8");
-      const text = decoder.decode(chunk);
+      const text = partialChunk + decoder.decode(chunk);
       const lines = text.split("\n");
+
+      // We want to ensure that the last line is not a fragment
+      // so we keep it and append it to the start of the next
+      // chunk.
+      partialChunk = lines.pop();
+
       for (const line of lines) {
         const sse = this.decode(line);
         if (sse) {
@@ -132,6 +143,17 @@ class Stream extends Readable {
           }
         }
       }
+    }
+
+    // Process the final line and ensure we have captured the final event.
+    this.decode(partialChunk);
+    const sse = this.decode("");
+    if (sse) {
+      if (sse.event === "error") {
+        throw new Error(sse.data);
+      }
+
+      yield sse;
     }
   }
 }

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -48,10 +48,12 @@ class Stream extends Readable {
   /**
    * Create a new stream of server-sent events.
    *
-   * @param {string} url The URL to connect to.
-   * @param {object} options The fetch options.
+   * @param {object} config
+   * @param {string} config.url The URL to connect to.
+   * @param {Function} [config.fetch] The fetch implemention to use.
+   * @param {object} [config.options] The fetch options.
    */
-  constructor(url, options) {
+  constructor({ url, fetch = globalThis.fetch, options = {} }) {
     if (!Readable) {
       throw new Error(
         "Readable streams are not supported. Please use Node.js 18 or later, or install the readable-stream package."
@@ -60,6 +62,7 @@ class Stream extends Readable {
 
     super();
     this.url = url;
+    this.fetch = fetch;
     this.options = options;
 
     this.event = null;
@@ -104,7 +107,7 @@ class Stream extends Readable {
   }
 
   async *[Symbol.asyncIterator]() {
-    const response = await fetch(this.url, {
+    const response = await this.fetch(this.url, {
       ...this.options,
       headers: {
         Accept: "text/event-stream",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "allowJs": true
   },
   "exclude": [
     "**/node_modules"


### PR DESCRIPTION
There's a subtle bug in the current `Stream` implementation where if the server emits lines in several chunks then we get "null" events in the async iterator.

For example:

```
event: output
id: 1
data: hello
-- chunk 2 --
data: world
-- chunk 3

event: done
id: 2
data: {}
```

Will result in:

```
SSE { id: 1, event: "output", data: "hello" }
SSE { id: null, event: null, data: "world" }
SSE { id: 2, event: "done", data: "{}" }
```

This PR fixes this, plus a few bugs in the `Stream` implementation:

- We now use the fetch() implementation provided to the Replicate constructor rather than the global.
- We raise an error if the stream endpoint does not respond with a 2xx status code.
- We now ensure that the `decode()` function in the `Stream` class processes full lines by retaining the last line of the current chunk and appending it to the start of the next chunk before splitting on newlines.
- Fixes the type definition for `validateWebhook` which returns a `Promise<boolean>` but is typed to return `boolean`.
