### PR TITLE
Add Support for Polyfilled 'crypto' Module.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,6 @@
-const crypto = require("node:crypto");
+let crypto;
+
+if (typeof crypto === "undefined") crypto = require("node:crypto");
 
 const ApiError = require("./error");
 


### PR DESCRIPTION
This PR allows the replicate-js package to run in environments where 'node:crypto' isn't available, given that `crypto` is polyfilled.

This change is necessary since environments like Vercel's Edge Runtime don't support 'node:crypto' but have a preinstalled `crypto` polyfill available.

This change doesn't affect Node.js users at all; tests continue to pass and 'node:crypto' is still imported.