### PR TITLE
Update CI configuration for integration test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
         node-version: [18.x, 20.x]
         suite: [commonjs, esm, typescript, cloudflare-worker]
+        exclude:
+          - suite: cloudflare-worker
+            node-version: 18.x # Only test Cloudflare suite with the latest Node version
       fail-fast: false
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
 
     strategy:
       matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
         node-version: [18.x, 20.x]
         suite: [commonjs, esm, typescript, cloudflare-worker]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
+      fail-fast: false
 
     env:
       REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}


### PR DESCRIPTION
This PR makes the following changes to our CI config for integration tests:

- Run with `fail-fast` set to `false` so that failures in one don't prevent the others from running.
- Run the Cloudflare Worker test suite with latest Node.js only, since Cloudflare doesn't itself use Node.js