### PR TITLE
Close the stream when receiving "done" event from the server

### DIFF
--- a/integration/cloudflare-worker/.npmrc
+++ b/integration/cloudflare-worker/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
-
+audit=false
+fund=false

--- a/integration/cloudflare-worker/index.test.js
+++ b/integration/cloudflare-worker/index.test.js
@@ -3,8 +3,8 @@ import { unstable_dev as dev } from "wrangler";
 import { test, after, before, describe } from "node:test";
 import assert from "node:assert";
 
-/** @type {import("wrangler").UnstableDevWorker} */
 describe("CloudFlare Worker", () => {
+  /** @type {import("wrangler").UnstableDevWorker} */
   let worker;
 
   before(async () => {
@@ -22,15 +22,20 @@ describe("CloudFlare Worker", () => {
     await worker.stop();
   });
 
-  test("worker streams back a response", { timeout: 1000 }, async () => {
+  test("worker streams back a response", { timeout: 5000 }, async () => {
     const resp = await worker.fetch();
     const text = await resp.text();
 
-    assert.ok(resp.ok, "status is 2xx");
-    assert(text.length > 0, "body.length is greater than 0");
+    assert.ok(resp.ok, `expected status to be 2xx but got ${resp.status}`);
+    assert(
+      text.length > 0,
+      "expected body to have content but got body.length of 0"
+    );
     assert(
       text.includes("Colin CloudFlare"),
-      "body includes stream characters"
+      `expected body to include "Colin CloudFlare" but got ${JSON.stringify(
+        text
+      )}`
     );
   });
 });

--- a/integration/commonjs/.npmrc
+++ b/integration/commonjs/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
-
+audit=false
+fund=false

--- a/integration/esm/.npmrc
+++ b/integration/esm/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
-
+audit=false
+fund=false

--- a/integration/typescript/.npmrc
+++ b/integration/typescript/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
-
+audit=false
+fund=false

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -62,7 +62,7 @@ function createReadableStream({ url, fetch, options = {} }) {
         const request = new Request(url, init);
         controller.error(
           new ApiError(
-            `Request to ${url} failed with status ${response.status}`,
+            `Request to ${url} failed with status ${response.status}: ${text}`,
             request,
             response
           )
@@ -72,15 +72,22 @@ function createReadableStream({ url, fetch, options = {} }) {
       const stream = response.body
         .pipeThrough(new TextDecoderStream())
         .pipeThrough(new EventSourceParserStream());
+
       for await (const event of stream) {
         if (event.event === "error") {
           controller.error(new Error(event.data));
-        } else {
-          controller.enqueue(
-            new ServerSentEvent(event.event, event.data, event.id)
-          );
+          break;
+        }
+
+        controller.enqueue(
+          new ServerSentEvent(event.event, event.data, event.id)
+        );
+
+        if (event.event === "done") {
+          break;
         }
       }
+
       controller.close();
     },
   });


### PR DESCRIPTION
This fixes a regression introduced with #214 where we were not exiting correctly when getting the `"done"` event from the server. This was picked up by the introduction of the CloudFlare integration tests added in #217 which uses the streaming API.

Once the fix was added it turns out that the `nock()` tests were incorrectly passing due to some internal weirdness when using `respondWith` and a `Readable` object. I wasn't able to get this working without hitting a different error:

    TypeError: Invalid state: Controller is already closed

It looks like nock is retaining some global state somewhere in it's implementation and streams are being retained across requests. No combination of resetting mocks seemed to fix it.

In the end I just mocked out the fetch function passed into the `createReadableStream` library and returned a `Response`. I think we should probably do this everywhere rather than use `nock()` as the Request/Response APIs provided by fetch are much better now than the old node http lib.