### PR TITLE
Unset Bun integration test timeout and automatically retry 3 times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,4 +166,7 @@ jobs:
           cd integration/${{ matrix.suite }}
           bun uninstall replicate
           bun install "file:../../${{ needs.build.outputs.tarball-name }}"
-          bun test
+          retries=3
+          for ((i=0; i<retries; i++)); do
+            bun test && break || echo "Test failed, retrying..."
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,4 +166,4 @@ jobs:
           cd integration/${{ matrix.suite }}
           bun uninstall replicate
           bun install "file:../../${{ needs.build.outputs.tarball-name }}"
-          bun test --timeout 30000
+          bun test

--- a/integration/bun/index.ts
+++ b/integration/bun/index.ts
@@ -15,6 +15,7 @@ export default async function main() {
   const output = [];
 
   for await (const { event, data } of replicate.stream(model, options)) {
+    console.log({ event, data });
     if (event === "output") {
       output.push(data);
     }


### PR DESCRIPTION
Related to #229 

This PR attempts to mitigate the impact of bun integration tests being flakey. First, it removes the custom 30s test timeout, since the model timing out isn't the problem. Second, it adds a loop to automatically retry `bun test` up to 3 times if any attempt fails.