### PR TITLE
Fix `Deployment` type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,10 +33,8 @@ declare module "replicate" {
       created_by: Account;
       configuration: {
         hardware: string;
-        scaling: {
-          min_instances: number;
-          max_instances: number;
-        };
+        min_instances: number;
+        max_instances: number;
       };
     };
   }

--- a/index.test.ts
+++ b/index.test.ts
@@ -791,10 +791,8 @@ describe("Replicate client", () => {
             },
             configuration: {
               hardware: "gpu-t4",
-              scaling: {
-                min_instances: 1,
-                max_instances: 5,
-              },
+              min_instances: 1,
+              max_instances: 5,
             },
           },
         });
@@ -832,10 +830,8 @@ describe("Replicate client", () => {
             },
             configuration: {
               hardware: "gpu-t4",
-              scaling: {
-                min_instances: 1,
-                max_instances: 5,
-              },
+              min_instances: 1,
+              max_instances: 5,
             },
           },
         });
@@ -878,10 +874,8 @@ describe("Replicate client", () => {
             },
             configuration: {
               hardware: "gpu-a40-large",
-              scaling: {
-                min_instances: 3,
-                max_instances: 10,
-              },
+              min_instances: 3,
+              max_instances: 10,
             },
           },
         });
@@ -905,12 +899,8 @@ describe("Replicate client", () => {
       expect(deployment.current_release.configuration.hardware).toBe(
         "gpu-a40-large"
       );
-      expect(
-        deployment.current_release.configuration.scaling?.min_instances
-      ).toBe(3);
-      expect(
-        deployment.current_release.configuration.scaling?.max_instances
-      ).toBe(10);
+      expect(deployment.current_release.configuration.min_instances).toBe(3);
+      expect(deployment.current_release.configuration.max_instances).toBe(10);
     });
     // Add more tests for error handling, edge cases, etc.
   });
@@ -935,7 +925,7 @@ describe("Replicate client", () => {
         });
 
       const deployments = await client.deployments.list();
-      expect(deployments.results.length).toBe(1)
+      expect(deployments.results.length).toBe(1);
     });
     // Add more tests for pagination, error handling, edge cases, etc.
   });


### PR DESCRIPTION
#223 added fields to the Deployment model provided by the new deployments.{get,list,update} endpoints. However, those were implemented against a version of the OpenAPI specification that disagreed with the actual API responses. Specifically, the `min_instances` and `max_instances` properties were listed as subproperties of a `scaling` object rather than direct fields.