### PR TITLE
Fix CI for Node 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -36,7 +36,7 @@ jobs:
       tarball-name: ${{ steps.pack.outputs.tarball-name }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: package-tarball
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: package-tarball
@@ -125,7 +125,7 @@ jobs:
         suite: [cloudflare-worker]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: package-tarball
@@ -154,7 +154,7 @@ jobs:
         suite: [bun]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: package-tarball

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
 
     strategy:
       matrix:
+        node-version: [20.x]
         browser: ["chromium", "firefox", "webkit"]
         suite: ["browser"]
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: "npm"
@@ -72,7 +72,7 @@ jobs:
         with:
           name: package-tarball
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -100,7 +100,7 @@ jobs:
         with:
           name: package-tarball
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -130,7 +130,7 @@ jobs:
         with:
           name: package-tarball
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
-        node-version: [18.x, 20.x]
+        # FIXME: Tests are failing on Node.js v20.12.1 (https://github.com/replicate/replicate-javascript/issues/237)
+        node-version: [18.x, 20.11.1]
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "cross-fetch": "^3.1.5",
         "jest": "^29.6.2",
-        "nock": "^14.0.0-beta.4",
+        "nock": "^14.0.0-beta.5",
         "publint": "^0.2.7",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.2"
@@ -4077,12 +4077,11 @@
       "dev": true
     },
     "node_modules/nock": {
-      "version": "14.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.4.tgz",
-      "integrity": "sha512-N9GIOnNFas/TtdCQpavpi6A6SyVVInkD/vrUCF2u51vlE2wSnqfPifVli6xSX8l6Lz/3sdSwPusE9n3KPDDh0g==",
+      "version": "14.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.5.tgz",
+      "integrity": "sha512-u255tf4DYvyErTlPZA9uTfXghiZZy+NflUOFONPVKZ5tP0yaHwKig28zyFOLhu8y5YcCRC+V5vDk4HHileh2iw==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "cross-fetch": "^3.1.5",
     "jest": "^29.6.2",
-    "nock": "^14.0.0-beta.4",
+    "nock": "^14.0.0-beta.5",
     "publint": "^0.2.7",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.2"


### PR DESCRIPTION
Resolves #237 

This PR pins the `test` job to the last known good version of Node.js, v20.12.1.

This is a problem with the test harness itself (specifically, the `nock` dependency), rather than the library. Pinning to an older version isn't ideal, but it's unlikely to hide actual problems with our code. And this unblocks us in the meantime, while we wait for an upstream fix or remove nock entirely. 