### PR TITLE
Update to ulti.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -133,7 +133,7 @@ function base64ToBytes(base64) {
  * @return {string}
  */
 function bytesToBase64(bytes) {
-  return btoa(String.fromCharCode.apply(null, new Uint8Array(bytes)));
+  return bytes.toString("base64")
 }
 
 /**


### PR DESCRIPTION
There was a problem with the `bytesToBase64` function where it was causing a error, so i used normal node functionality to convert the bytes into base64 which fixed the error.