### PR TITLE
fix: remove stable node.js API web crypto polyfill

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -86,12 +86,6 @@ async function validateWebhook(requestData, secret) {
  */
 async function createHMACSHA256(secret, data) {
   const encoder = new TextEncoder();
-  let crypto = globalThis.crypto;
-
-  // In Node 18 the `crypto` global is behind a --no-experimental-global-webcrypto flag
-  if (typeof crypto === "undefined" && typeof require === "function") {
-    crypto = require("node:crypto").webcrypto;
-  }
 
   const key = await crypto.subtle.importKey(
     "raw",


### PR DESCRIPTION
Fixes: https://github.com/replicate/replicate-javascript/issues/225

This won't fix https://github.com/replicate/replicate-javascript/issues/210 because react native doesn't have webcrypto API