### PR TITLE
Use Bearer authorization scheme

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ class Replicate {
 
     const headers = {};
     if (auth) {
-      headers["Authorization"] = `Token ${auth}`;
+      headers["Authorization"] = `Bearer ${auth}`;
     }
     headers["Content-Type"] = "application/json";
     headers["User-Agent"] = userAgent;


### PR DESCRIPTION
Replicate's API now supports the standard [Bearer authentication scheme](https://swagger.io/docs/specification/authentication/bearer-authentication/). 

https://replicate.com/changelog/2024-04-03-bearer-tokens

For compatibility with existing clients, the existing `Token` scheme will be supported indefinitely. But going forward, the new `Bearer` scheme is preferred.