### PR TITLE
fix rangeerror for input buffers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -133,7 +133,12 @@ function base64ToBytes(base64) {
  * @return {string}
  */
 function bytesToBase64(bytes) {
-  return btoa(String.fromCharCode.apply(null, new Uint8Array(bytes)));
+  const uint8Array = new Uint8Array(bytes);
+  let binaryString = "";
+  for (let i = 0; i < uint8Array.length; i++) {
+    binaryString += String.fromCharCode(uint8Array[i]);
+  }
+  return btoa(binaryString);
 }
 
 /**


### PR DESCRIPTION
Resolves https://github.com/replicate/replicate-javascript/issues/247

This PR was written by the language model gods. Here's what they have to say about the reasoning behind the fix:

---

The error "RangeError: Maximum call stack size exceeded" in the original function arises due to the use of `String.fromCharCode.apply(null, new Uint8Array(bytes))`. This method attempts to convert a `Uint8Array` into a string by applying `String.fromCharCode` to each byte in the array. However, when the `Uint8Array` is large, this approach leads to a very large number of arguments being passed to `String.fromCharCode` via the `apply` method, which exceeds the JavaScript engine's maximum call stack size.

JavaScript has a limit on the number of arguments that can be passed to a function, and exceeding this limit results in a stack overflow error, as seen here. This is particularly problematic with large binary data like images, where the byte array can be very large.

The refactored bytesToBase64 function avoids this issue by iteratively building a string from the Uint8Array using a loop. In each iteration, it converts a single byte to a character using String.fromCharCode and appends this character to a string. This method does not involve passing a large number of arguments to a function at once, thus it stays within the call stack limit and avoids the error.

This approach is more efficient in terms of memory usage and avoids the call stack limit issue, making it suitable for handling large data arrays.