### PR TITLE
Remove the node protocol from the require statement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,25 @@ jobs:
           for ((i=0; i<retries; i++)); do
             bun test && break || echo "Test failed, retrying..."
           done
+
+  integration-nextjs:
+    needs: [test, build]
+    runs-on: ubuntu-latest
+
+    env:
+      REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: package-tarball
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "npm"
+      - run: |
+          npm --prefix integration/next install
+          npm --prefix integration/next install "./${{ needs.build.outputs.tarball-name }}"
+          npm --prefix integration/next run build

--- a/integration/browser/index.test.js
+++ b/integration/browser/index.test.js
@@ -6,7 +6,7 @@ const result = await build({
   entryPoints: ["index.js"],
   bundle: true,
   platform: "browser",
-  external: ["node:crypto"],
+  external: ["crypto"],
   write: false,
 });
 const source = new TextDecoder().decode(result.outputFiles[0].contents);

--- a/integration/browser/index.test.js
+++ b/integration/browser/index.test.js
@@ -6,7 +6,7 @@ const result = await build({
   entryPoints: ["index.js"],
   bundle: true,
   platform: "browser",
-  external: ["crypto"],
+  external: ["node:crypto"],
   write: false,
 });
 const source = new TextDecoder().decode(result.outputFiles[0].contents);

--- a/integration/next/.npmrc
+++ b/integration/next/.npmrc
@@ -1,0 +1,3 @@
+package-lock=false
+audit=false
+fund=false

--- a/integration/next/middleware.ts
+++ b/integration/next/middleware.ts
@@ -1,0 +1,17 @@
+// NOTE: This file currently doesn't do anything other than
+// validate that `next build` works as expected. We can
+// extend it in future to support actual middleware tests.
+import { NextRequest } from "next/server";
+import Replicate from "replicate";
+
+// Limit the middleware to paths starting with `/api/`
+export const config = {
+  matcher: "/api/:function*",
+};
+
+const replicate = new Replicate();
+
+export function middleware(request: NextRequest) {
+  const output = replicate.run("foo/bar");
+  return Response.json({ output }, 200);
+}

--- a/integration/next/package.json
+++ b/integration/next/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "replicate-next",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next",
+    "build": "rm -rf .next && next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "replicate": "../../"
+  }
+}

--- a/integration/next/pages/index.js
+++ b/integration/next/pages/index.js
@@ -1,0 +1,5 @@
+export default () => (
+	<main>
+		<h1>Welcome to Next.js</h1>
+	</main>
+)

--- a/lib/util.js
+++ b/lib/util.js
@@ -90,9 +90,18 @@ async function createHMACSHA256(secret, data) {
 
   // In Node 18 the `crypto` global is behind a --no-experimental-global-webcrypto flag
   if (typeof crypto === "undefined" && typeof require === "function") {
-    // NOTE: We explicitly do not include the "node:crypto" namespace here
-    // as this seems to create issues with bundlers like pnpm.
-    crypto = require("crypto").webcrypto;
+    // NOTE: Webpack (primarily as it's used by Next.js) and perhaps some
+    // other bundlers do not currently support the `node` protocol and will
+    // error if it's found in the source. Other platforms like CloudFlare
+    // will only support requires when using the node protocol.
+    //
+    // As this line is purely to support Node 18.x we make an indirect request
+    // to the require function which fools Webpack...
+    //
+    // We may be able to remove this in future as it looks like Webpack is getting
+    // support for requiring using the `node:` protocol.
+    // See: https://github.com/webpack/webpack/issues/18277
+    crypto = require.call(null, "node:crypto").webcrypto;
   }
 
   const key = await crypto.subtle.importKey(

--- a/lib/util.js
+++ b/lib/util.js
@@ -90,7 +90,9 @@ async function createHMACSHA256(secret, data) {
 
   // In Node 18 the `crypto` global is behind a --no-experimental-global-webcrypto flag
   if (typeof crypto === "undefined" && typeof require === "function") {
-    crypto = require("node:crypto").webcrypto;
+    // NOTE: We explicitly do not include the "node:crypto" namespace here
+    // as this seems to create issues with bundlers like pnpm.
+    crypto = require("crypto").webcrypto;
   }
 
   const key = await crypto.subtle.importKey(


### PR DESCRIPTION
This should improve the situation for certain JavaScript bundlers in the ecosystem which do not like the `node:crypto` require statement, see #225 and #243.