### PR TITLE
Fix passing abort signal into run method

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,14 +162,18 @@ class Replicate {
           progress(updatedPrediction);
         }
 
-        if (signal && signal.aborted) {
-          await this.predictions.cancel(updatedPrediction.id);
+        // We handle the cancel later in the function.
+        if (signal?.aborted) {
           return true; // stop polling
         }
 
         return false; // continue polling
       }
     );
+
+    if (signal?.aborted) {
+      prediction = await this.predictions.cancel(prediction.id);
+    }
 
     // Call progress callback with the completed prediction object
     if (progress) {

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ class Replicate {
    * @returns {Promise<object>} - Resolves with the output of running the model
    */
   async run(ref, options, progress) {
-    const { wait, ...data } = options;
+    const { wait, signal, ...data } = options;
 
     const identifier = ModelVersionIdentifier.parse(ref);
 
@@ -152,8 +152,6 @@ class Replicate {
     if (progress) {
       progress(prediction);
     }
-
-    const { signal } = options;
 
     prediction = await this.wait(
       prediction,

--- a/index.test.ts
+++ b/index.test.ts
@@ -1233,11 +1233,14 @@ describe("Replicate client", () => {
     test("Aborts the operation when abort signal is invoked", async () => {
       const controller = new AbortController();
       const { signal } = controller;
+      let body: Record<string, unknown> | undefined;
 
       const scope = nock(BASE_URL)
-        .post("/predictions", (body) => {
+        .post("/predictions", (_body) => {
+          // Should not pass the signal object in the body.
+          body = _body;
           controller.abort();
-          return body;
+          return _body;
         })
         .reply(201, {
           id: "ufawqhfynnddngldkgtslldrkq",
@@ -1263,7 +1266,10 @@ describe("Replicate client", () => {
         }
       );
 
+      expect(body).toBeDefined();
+      expect(body?.["signal"]).toBeUndefined();
       expect(signal.aborted).toBe(true);
+      expect(output).toBeUndefined();
 
       scope.done();
     });

--- a/index.test.ts
+++ b/index.test.ts
@@ -1258,18 +1258,39 @@ describe("Replicate client", () => {
           status: "canceled",
         });
 
-      await client.run(
+      const onProgress = jest.fn();
+      const output = await client.run(
         "owner/model:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
         {
           input: { text: "Hello, world!" },
           signal,
-        }
+        },
+        onProgress
       );
 
       expect(body).toBeDefined();
       expect(body?.["signal"]).toBeUndefined();
       expect(signal.aborted).toBe(true);
       expect(output).toBeUndefined();
+
+      expect(onProgress).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          status: "processing",
+        })
+      );
+      expect(onProgress).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          status: "processing",
+        })
+      );
+      expect(onProgress).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          status: "canceled",
+        })
+      );
 
       scope.done();
     });


### PR DESCRIPTION
This PR fixes two issues with passing the `AbortController` as a `signal` option to the `replicate.run()` method.

Firstly now extract the `signal` property from the `run()` options and do not pass on as part of the API body. The backend has recently started validating the body payload so this is now resulting as an API error. This fixes the issue reported in #249.

Secondly, we now call the `onProgress` handler with the terminal canceled prediction. Previously when aborting a `run()` request we were dropping the final canceled prediction object and calling the `onProgress` callback with a stale "processing" object.

I've updated the tests to verify both of these changes.
