### PR TITLE
Remove use of optional chaining in client

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ class Replicate {
         }
 
         // We handle the cancel later in the function.
-        if (signal?.aborted) {
+        if (signal && signal.aborted) {
           return true; // stop polling
         }
 
@@ -171,7 +171,7 @@ class Replicate {
       }
     );
 
-    if (signal?.aborted) {
+    if (signal && signal.aborted) {
       prediction = await this.predictions.cancel(prediction.id);
     }
 


### PR DESCRIPTION
Despite the [optional chaining (`?.`) operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) being supported in Node >= 14, I continue to see anecdotal reports from users of other libraries encountering `SyntaxError: Unexpected token '.'`, even when targeting Node.js 20.

With all the weird, frustrating compatibility issues throughout the JS ecosystem, I take some comfort in having some control that I can exercise over this one. (Maybe I'm paranoid, but hey — at least I'm consistent about it?)