### PR TITLE
Delete explicit `Content-Type` for `FormData` input

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,12 +220,13 @@ class Replicate {
       url.searchParams.append(key, value);
     }
 
-    const headers = {};
+    const headers = {
+      "Content-Type": "application/json",
+      "User-Agent": userAgent,
+    };
     if (auth) {
       headers["Authorization"] = `Bearer ${auth}`;
     }
-    headers["Content-Type"] = "application/json";
-    headers["User-Agent"] = userAgent;
     if (options.headers) {
       for (const [key, value] of Object.entries(options.headers)) {
         headers[key] = value;

--- a/index.js
+++ b/index.js
@@ -235,6 +235,8 @@ class Replicate {
     let body = undefined;
     if (data instanceof FormData) {
       body = data;
+      // biome-ignore lint/performance/noDelete:
+      delete headers["Content-Type"]; // Use automatic content type header
     } else if (data) {
       body = JSON.stringify(data);
     }

--- a/index.test.ts
+++ b/index.test.ts
@@ -296,7 +296,6 @@ describe("Replicate client", () => {
 
         nock(BASE_URL)
           .post("/files")
-          .matchHeader("Content-Type", "multipart/form-data")
           .reply(201, {
             urls: {
               get: "https://replicate.com/api/files/123",
@@ -317,7 +316,6 @@ describe("Replicate client", () => {
             prompt: "Tell me a story",
             data,
           },
-          stream: true,
         });
 
         expect(client.fetch).toHaveBeenCalledWith(
@@ -325,9 +323,7 @@ describe("Replicate client", () => {
           {
             method: "POST",
             body: expect.any(FormData),
-            headers: expect.objectContaining({
-              "Content-Type": "multipart/form-data",
-            }),
+            headers: expect.any(Object),
           }
         );
         const form = mockedFetch.mock.calls[0][1]?.body as FormData;


### PR DESCRIPTION
Follow-up to #184 

The `multipart/form-data` header set in `createFile` is missing a boundary, which causes uploads to fail. Deleting this header in `request` allows `fetch` to automatically generate the boundary for the `FormData` object[^1].

[^1]: We can't just omit the header, as it would otherwise default to `application/json`.