### PR TITLE
Update blob creation to handle `Buffer` inputs correctly in `createFile`

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -15,7 +15,11 @@ async function createFile(file, metadata = {}) {
     blob = file;
   } else if (Buffer.isBuffer(file)) {
     filename = `buffer_${Date.now()}`;
-    blob = new Blob(file, { type: "application/octet-stream" });
+    const bytes = new Uint8Array(file);
+    blob = new Blob([bytes], {
+      type: "application/octet-stream",
+      name: filename,
+    });
   } else {
     throw new Error("Invalid file argument, must be a Blob, File or Buffer");
   }


### PR DESCRIPTION
Follow-up to #184 

This PR fixes how a `Blob` object is constructed from a `Buffer` object in `createFile`.