### PR TITLE
Re-raise 4xx responses from server when uploading files

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -67,18 +67,11 @@ async function validateWebhook(requestData, secret) {
 
   const signedContent = `${id}.${timestamp}.${body}`;
 
-  const computedSignature = await createHMACSHA256(
-    signingSecret.split("_").pop(),
-    signedContent
-  );
+  const computedSignature = await createHMACSHA256(signingSecret.split("_").pop(), signedContent);
 
-  const expectedSignatures = signature
-    .split(" ")
-    .map((sig) => sig.split(",")[1]);
+  const expectedSignatures = signature.split(" ").map((sig) => sig.split(",")[1]);
 
-  return expectedSignatures.some(
-    (expectedSignature) => expectedSignature === computedSignature
-  );
+  return expectedSignatures.some((expectedSignature) => expectedSignature === computedSignature);
 }
 
 /**
@@ -105,13 +98,9 @@ async function createHMACSHA256(secret, data) {
     crypto = require.call(null, "node:crypto").webcrypto;
   }
 
-  const key = await crypto.subtle.importKey(
-    "raw",
-    base64ToBytes(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
+  const key = await crypto.subtle.importKey("raw", base64ToBytes(secret), { name: "HMAC", hash: "SHA-256" }, false, [
+    "sign",
+  ]);
 
   const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(data));
   return bytesToBase64(signature);
@@ -235,6 +224,9 @@ async function transformFileInputs(client, inputs, strategy) {
       try {
         return await transformFileInputsToReplicateFileURLs(client, inputs);
       } catch (error) {
+        if (error instanceof ApiError && error.response.status >= 400 && error.response.status < 500) {
+          throw error;
+        }
         return await transformFileInputsToBase64EncodedDataURIs(inputs);
       }
     default:
@@ -296,7 +288,7 @@ async function transformFileInputsToBase64EncodedDataURIs(inputs) {
     totalBytes += buffer.byteLength;
     if (totalBytes > MAX_DATA_URI_SIZE) {
       throw new Error(
-        `Combined filesize of prediction ${totalBytes} bytes exceeds 10mb limit for inline encoding, please provide URLs instead`
+        `Combined filesize of prediction ${totalBytes} bytes exceeds 10mb limit for inline encoding, please provide URLs instead`,
       );
     }
 
@@ -354,14 +346,11 @@ function isPlainObject(value) {
   if (proto === null) {
     return true;
   }
-  const Ctor =
-    Object.prototype.hasOwnProperty.call(proto, "constructor") &&
-    proto.constructor;
+  const Ctor = Object.prototype.hasOwnProperty.call(proto, "constructor") && proto.constructor;
   return (
     typeof Ctor === "function" &&
     Ctor instanceof Ctor &&
-    Function.prototype.toString.call(Ctor) ===
-      Function.prototype.toString.call(Object)
+    Function.prototype.toString.call(Ctor) === Function.prototype.toString.call(Object)
   );
 }
 


### PR DESCRIPTION
Fixes #270

We were falling back to base64 encoding the file data when requests to upload the file failed. However if the client makes an invalid request such as failing to include Authorization headers by forgetting to auth then we should surface these errors.

This commit now re-raises any 4xx errors returned while attempting to upload a file and adds tests to verify the behavior.
