### PR TITLE
Add "strict" interface to `replicate.run()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,17 +145,18 @@ declare module "replicate" {
     fetch: (input: Request | string, init?: RequestInit) => Promise<Response>;
     fileEncodingStrategy: FileEncodingStrategy;
 
-    run(
+    run<T>(
       identifier: `${string}/${string}` | `${string}/${string}:${string}`,
       options: {
         input: object;
         wait?: { interval?: number };
+        strict?: boolean;
         webhook?: string;
         webhook_events_filter?: WebhookEventType[];
         signal?: AbortSignal;
       },
       progress?: (prediction: Prediction) => void
-    ): Promise<object>;
+    ): Promise<T>;
 
     stream(
       identifier: `${string}/${string}` | `${string}/${string}:${string}`,

--- a/lib/util.js
+++ b/lib/util.js
@@ -434,7 +434,85 @@ async function* streamAsyncIterator(stream) {
   }
 }
 
+/**
+ * Implements the Blob interface but the data is loaded lazily when needed from
+ * a source URL provided on creation.
+ */
+class LazyFile {
+  #blob = null;
+  #source = null;
+  #name = null;
+
+  constructor(source, options) {
+    if (source instanceof URL) {
+      this.#source = source;
+    } else {
+      this.#blob = new Blob(source, options);
+    }
+
+    this.#name = options?.name;
+  }
+
+  toString() {
+    return `[LazyFile ${this.#source ?? this.#blob.toString()}]`;
+  }
+
+  toJSON() {
+    return {
+      name: this.#name ?? null,
+      size: this.#blob?.size ?? null,
+      source: this.#source ?? "",
+      type: this.#blob?.type ?? null,
+    };
+  }
+
+  get source() {
+    return this.#source;
+  }
+
+  get #resolved() {
+    if (this.#blob) {
+      return Promise.resolve(this.#blob);
+    }
+
+    return fetch(this.#source).then(async (response) => {
+      this.#name = this.#name ?? response.headers.get("filename") ?? "";
+      this.#blob = await response.blob();
+      return this.#blob;
+    });
+  }
+
+  get name() {
+    return this.#resolved.then(() => this.#name);
+  }
+
+  get type() {
+    return this.#resolved.then((b) => b.type);
+  }
+
+  get size() {
+    return this.#resolved.then((b) => b.size);
+  }
+
+  async arrayBuffer(...args) {
+    return this.#resolved.then((b) => b.arrayBuffer(...args));
+  }
+
+  async slice(...args) {
+    return this.#resolved.then((b) => b.slice(...args));
+  }
+
+  async stream(...args) {
+    return this.#resolved.then((b) => b.stream(...args));
+  }
+
+  async text(...args) {
+    return this.#resolved.then((b) => b.text(...args));
+  }
+}
+
 module.exports = {
+  LazyFile,
   transformFileInputs,
   validateWebhook,
   withAutomaticRetries,


### PR DESCRIPTION
This PR implements a new `strict` option that can be passed to `run()` to coerce the output into the same data types as defined by the model schema.

```js
const stream = replicate.run("my-org/my-llm", {strict: true, input: { ... }});
for await (const chunk in stream) {
  ...
}

const files = replicate.run("my-org/my-gen-img", {strict: true, input: { ... }});
for await (const image in files) {
  const img = Object.createURLObject(await file.blob());
}

const file = replicate.run("my-org/my-model", {strict: true, input: { ... }});
const data = await file.arrayBuffer();
```

The main two benefits here are that:

1. Iterators get converted into actual async iterators instead of just arrays which means the `stream()` method can be deprecated in favor of a single interface. This opens up opportunities for streaming other types of output too.
2. `Path` & `File` outputs are backed by a `Blob` like representation that can be used to download the data opening up opportunities to stream files directly in the client. Note, that we don't use `Blob`, `File` or `ArrayBuffer` directly because it's likely the client will want the opportunity to decide whether to actually download the file or not. Similar to how `body` on `Response` is not consumed until an async read method is called. **Feedback on this appreciated**.

> [!NOTE]
> The intention here is that once this code is merged and validated we migrate the SDKs to use this as the default interface to `run()` (a breaking change). The `strict` flag is a way of soft launching the feature. The name `strict` was chosen as in JavaScript land "use strict" and TypeScript `--strict` mode are existing functionality for tightening up interfaces.

The need to download the schema for the version is currently unfortunate, I'm also looking at extending the Prediction interface to include `input_schema` and `output_schema` to reduce this additional request.

**Implementation**

The bulk of the code exists in the `coerceOutput()` function, I think it implements the bulk of the Cog Output interface, but I may have missed some edge cases.

**TODO**

- [ ] Currently there is no support for `enum` types.
- [ ] Currently there is no support for date strings.