### PR TITLE
Fix `validateWebhook` backwards incompatibility with Node 18.x

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -55,6 +55,8 @@ async function validateWebhook(requestData, secret) {
     }
   } else if (isTypedArray(body)) {
     body = await new Blob([body]).text();
+  } else if (typeof body === "object") {
+    body = JSON.stringify(body);
   } else if (typeof body !== "string") {
     throw new Error("Invalid body type");
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -35,9 +35,15 @@ async function validateWebhook(requestData, secret) {
   const signingSecret = secret || requestData.secret;
 
   if (requestData && requestData.headers && requestData.body) {
-    id = requestData.headers.get("webhook-id");
-    timestamp = requestData.headers.get("webhook-timestamp");
-    signature = requestData.headers.get("webhook-signature");
+    id =
+      requestData.headers["webhook-id"] ||
+      requestData.headers.get?.("webhook-id");
+    timestamp =
+      requestData.headers["webhook-timestamp"] ||
+      requestData.headers.get?.("webhook-timestamp");
+    signature =
+      requestData.headers["webhook-signature"] ||
+      requestData.headers.get?.("webhook-signature");
     body = requestData.body;
   }
 


### PR DESCRIPTION
Duplicate of #298, but opened on a branch rather than a fork to run integration tests.

---

This pull request fixes: https://github.com/replicate/replicate-javascript/issues/297

---

To make the `validateWebhook` function backward compatible with Node.js 18.x and Next.js 12.x, we need to access the headers with a slightly different syntax.

After making that adjustment, I also discovered a version incompatibility with the `requestData.body` value. I fixed that by stringifying the `requestData.body`, and then the `validateWebhook` function started working as expected.

