### PR TITLE
Introduce experimental FileOutput interface for models that output File and Path types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,12 @@ declare module "replicate" {
     response: Response;
   }
 
+  export interface FileOutput extends ReadableStream {
+    blob(): Promise<Blob>;
+    url(): URL;
+    toString(): string;
+  }
+
   export interface Account {
     type: "user" | "organization";
     username: string;
@@ -137,6 +143,7 @@ declare module "replicate" {
         init?: RequestInit
       ) => Promise<Response>;
       fileEncodingStrategy?: FileEncodingStrategy;
+      useFileOutput?: boolean;
     });
 
     auth: string;

--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ class Replicate {
       options.userAgent || `replicate-javascript/${packageJSON.version}`;
     this.baseUrl = options.baseUrl || "https://api.replicate.com/v1";
     this.fetch = options.fetch || globalThis.fetch;
-    this.fileEncodingStrategy = options.fileEncodingStrategy ?? "default";
-    this.useFileOutput = options.useFileOutput ?? false;
+    this.fileEncodingStrategy = options.fileEncodingStrategy || "default";
+    this.useFileOutput = options.useFileOutput || false;
 
     this.accounts = {
       current: accounts.current.bind(this),

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const ApiError = require("./lib/error");
 const ModelVersionIdentifier = require("./lib/identifier");
-const { createReadableStream } = require("./lib/stream");
+const { createReadableStream, createFileOutput } = require("./lib/stream");
 const {
+  transform,
   withAutomaticRetries,
   validateWebhook,
   parseProgressFromLogs,
@@ -47,6 +48,7 @@ class Replicate {
    * @param {string} options.userAgent - Identifier of your app
    * @param {string} [options.baseUrl] - Defaults to https://api.replicate.com/v1
    * @param {Function} [options.fetch] - Fetch function to use. Defaults to `globalThis.fetch`
+   * @param {boolean} [options.useFileOutput] - Set to `true` to return `FileOutput` objects from `run` instead of URLs, defaults to false.
    * @param {"default" | "upload" | "data-uri"} [options.fileEncodingStrategy] - Determines the file encoding strategy to use
    */
   constructor(options = {}) {
@@ -58,6 +60,7 @@ class Replicate {
     this.baseUrl = options.baseUrl || "https://api.replicate.com/v1";
     this.fetch = options.fetch || globalThis.fetch;
     this.fileEncodingStrategy = options.fileEncodingStrategy ?? "default";
+    this.useFileOutput = options.useFileOutput ?? false;
 
     this.accounts = {
       current: accounts.current.bind(this),
@@ -196,7 +199,17 @@ class Replicate {
       throw new Error(`Prediction failed: ${prediction.error}`);
     }
 
-    return prediction.output;
+    return transform(prediction.output, (value) => {
+      if (
+        typeof value === "string" &&
+        (value.startsWith("https:") || value.startsWith("data:"))
+      ) {
+        return this.useFileOutput
+          ? createFileOutput({ url: value, fetch: this.fetch })
+          : value;
+      }
+      return value;
+    });
   }
 
   /**

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -98,7 +98,61 @@ function createReadableStream({ url, fetch, options = {} }) {
   });
 }
 
+function createFileOutput({ url, fetch }) {
+  let type = "application/octet-stream";
+
+  class FileOutput extends ReadableStream {
+    async blob() {
+      const chunks = [];
+      for await (const chunk of this) {
+        chunks.push(chunk);
+      }
+      return new Blob(chunks, { type });
+    }
+
+    url() {
+      return new URL(url);
+    }
+
+    toString() {
+      return url;
+    }
+  }
+
+  return new FileOutput({
+    async start(controller) {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        const text = await response.text();
+        const request = new Request(url, init);
+        controller.error(
+          new ApiError(
+            `Request to ${url} failed with status ${response.status}: ${text}`,
+            request,
+            response
+          )
+        );
+      }
+
+      if (response.headers.get("Content-Type")) {
+        type = response.headers.get("Content-Type");
+      }
+
+      try {
+        for await (const chunk of streamAsyncIterator(response.body)) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+}
+
 module.exports = {
+  createFileOutput,
   createReadableStream,
   ServerSentEvent,
 };

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -98,6 +98,15 @@ function createReadableStream({ url, fetch, options = {} }) {
   });
 }
 
+/**
+ * Create a new readable stream for an output file
+ * created by running a Replicate model.
+ *
+ * @param {object} config
+ * @param {string} config.url The URL to connect to.
+ * @param {typeof fetch} [config.fetch] The URL to connect to.
+ * @returns {ReadableStream<Uint8Array>}
+ */
 function createFileOutput({ url, fetch }) {
   let type = "application/octet-stream";
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -318,7 +318,7 @@ async function transformFileInputsToBase64EncodedDataURIs(inputs) {
     }
 
     const data = bytesToBase64(buffer);
-    mime = mime ?? "application/octet-stream";
+    mime = mime || "application/octet-stream";
 
     return `data:${mime};base64,${data}`;
   });

--- a/lib/util.js
+++ b/lib/util.js
@@ -452,6 +452,7 @@ async function* streamAsyncIterator(stream) {
 }
 
 module.exports = {
+  transform,
   transformFileInputs,
   validateWebhook,
   withAutomaticRetries,


### PR DESCRIPTION
This PR is a proposal to add a new `FileOutput` type to the client SDK to abstract away file outputs from Replicate models.

It can be enabled by passing the `useFileOutput` flag to the Replicate constructor.

```js
const replicate = new Replicate({ useFileOutput: true });
```

When enabled any URLs or data-uris will be converted into a FileOutput type. This is essentially a `ReadableStream` that has two additional methods `url()` to return the underlying URL and `blob()` which will return a `Blob()` instance with the file data loaded into memory.
  
The intention here is to make it easier to work with file outputs and allows us to optimize the delivery of file assets to the client in future iterations.

Usage is as follows:

```js
const [output] = await replicate.run("black-forest-labs/flux-schnell", { 
	  input: {
	    prompt: "astronaut riding a rocket like a horse"
	  }
});
```

For most basic cases you'll want to utilize either the `url()` or `blob()` methods depending on whether you want to directly consume the file or pass it on.

To access the file URL:

```js
console.log(output.url()) // "https://delivery.replicate.com/..."
```

To consume the file directly:

```js
// Assign an image directly to an image tag.
img.src = URL.createObjectURL(await output.blob());
```

Or for very large files they can be streamed:

```js
for await (const chunk of output) {
  console.log(chunk); // UInt8Array
}
```

Or passed on to methods that support `ReadableStream`.

```js
fs.writeFile("my-image.png", output);
```

An effort has been made to maintain backwards compatibility by implementing a `toString()` method which should cause the `FileObject` to act like a URL string.

```js
const data = await fetch(output).then(r => r.blob()); // Blob
```

  