### PR TITLE
document typescript usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,32 @@ const output = await replicate.run(model, { input });
 > upload the file to your own storage provider
 > and pass a publicly accessible URL.
 
+## TypeScript usage
+
+This library exports TypeScript definitions. You can import them like this:
+
+```ts
+import Replicate, { Prediction } from 'replicate';
+```
+
+Here's an example that uses the `Prediction` type with a custom `onProgress` callback:
+
+```ts
+import Replicate, { Prediction } from 'replicate';
+
+const replicate = new Replicate();
+const model = "black-forest-labs/flux-schnell";
+const prompt = "a 19th century portrait of a raccoon gentleman wearing a suit";
+const onProgress = (prediction: Prediction) => {
+  console.log({ prediction });
+};
+
+const output = await replicate.run(model, { input: { prompt } }, onProgress)
+console.log({ output })
+```
+
+See the full list of exported types in [index.d.ts](./index.d.ts).
+
 ### Webhooks
 
 Webhooks provide real-time updates about your prediction. Specify an endpoint when you create a prediction, and Replicate will send HTTP POST requests to that URL when the prediction is created, updated, and finished.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const output = await replicate.run(model, { input });
 This library exports TypeScript definitions. You can import them like this:
 
 ```ts
-import Replicate, { Prediction } from 'replicate';
+import Replicate, { type Prediction } from 'replicate';
 ```
 
 Here's an example that uses the `Prediction` type with a custom `onProgress` callback:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ import Replicate, { type Prediction } from 'replicate';
 Here's an example that uses the `Prediction` type with a custom `onProgress` callback:
 
 ```ts
-import Replicate, { Prediction } from 'replicate';
+import Replicate, { type Prediction } from 'replicate';
 
 const replicate = new Replicate();
 const model = "black-forest-labs/flux-schnell";

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ import Replicate, { Prediction } from 'replicate';
 const replicate = new Replicate();
 const model = "black-forest-labs/flux-schnell";
 const prompt = "a 19th century portrait of a raccoon gentleman wearing a suit";
-const onProgress = (prediction: Prediction) => {
+function onProgress(prediction: Prediction) {
   console.log({ prediction });
-};
+}
 
 const output = await replicate.run(model, { input: { prompt } }, onProgress)
 console.log({ output })


### PR DESCRIPTION
I was using the Replicate client in a TypeScript project with an aggressive linter today, and it wasn't immediately obvious to me how to specify the types.

This PR adds a bit of documentation to the README that shows how to import the types ESM-style, and how to use them in a real-world example.