### PR TITLE
docs: create predictions for official models

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,8 +615,9 @@ const response = await replicate.predictions.create(options);
 
 | name                            | type     | description                                                                                                                      |
 | ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `options.version`               | string   | **Required**. The model version                                                                                                  |
 | `options.input`                 | object   | **Required**. An object with the model's inputs                                                                                  |
+| `options.model`                 | string   | The name of the model, e.g. `black-forest-labs/flux-schnell`. This is required if you're running an [official model](https://replicate.com/explore#official-models).                                                                                                   |
+| `options.version`               | string   | The 64-character [model version id](https://replicate.com/docs/topics/models/versions), e.g. `80537f9eead1a5bfa72d5ac6ea6414379be41d4d4f6679fd776e9535d1eb58bb`. This is required if you're not specifying a `model`.                                                                                                  |
 | `options.stream`                | boolean  | Requests a URL for streaming output output                                                                                       |
 | `options.webhook`               | string   | An HTTPS URL for receiving a webhook when the prediction has new output                                                          |
 | `options.webhook_events_filter` | string[] | You can change which events trigger webhook requests by specifying webhook events (`start` \| `output` \| `logs` \| `completed`) |


### PR DESCRIPTION
This PR updates the docs for `replicate.predictions.create()` to clarify that `model` is an option that can be provided as an alternative to `version` when running an official model.

Rendered: https://github.com/replicate/replicate-javascript/tree/docs-create-predictions-for-official-models#replicatepredictionscreate