### PR TITLE
Update deployments.createPrediction to use wait

### DIFF
--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -9,11 +9,11 @@ const { transformFileInputs } = require("./util");
  * @param {object} options.input - Required. An object with the model inputs
  * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
  * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
- * @param {boolean} [options.block] - Whether to wait until the prediction is completed before returning. Defaults to false
+ * @param {boolean|integer} [options.wait] - Whether to wait until the prediction is completed before returning. If an integer is provided, it will wait for that many seconds. Defaults to false
  * @returns {Promise<object>} Resolves with the created prediction data
  */
 async function createPrediction(deployment_owner, deployment_name, options) {
-  const { input, block, ...data } = options;
+  const { input, wait, ...data } = options;
 
   if (data.webhook) {
     try {
@@ -25,8 +25,13 @@ async function createPrediction(deployment_owner, deployment_name, options) {
   }
 
   const headers = {};
-  if (block) {
-    headers["Prefer"] = "wait";
+  if (wait) {
+    if (typeof wait === "number") {
+      const n = Math.max(1, Math.ceil(Number(wait)) || 1);
+      headers["Prefer"] = `wait=${n}`;
+    } else {
+      headers["Prefer"] = "wait";
+    }
   }
 
   const response = await this.request(


### PR DESCRIPTION
A first draft of this interface used `block`, but we ended up going with `wait` (as either a boolean or a number) for the predictions.createPrediction method. This commit brings the two implementations inline, and deprecates the `block` parameter.

Note: it would be nice to emit a warning about the deprecation if this method is called with the `block` parameter, but I'm not sure how to do that reliably across platforms. Advice welcome!