### PR TITLE
Add support for `AbortSignal` to all API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,12 +1215,18 @@ const response = await replicate.request(route, parameters);
 
 | name                 | type   | description                                                  |
 | -------------------- | ------ | ------------------------------------------------------------ |
-| `options.route`      | string | Required. REST API endpoint path.                            |
-| `options.parameters` | object | URL, query, and request body parameters for the given route. |
+| `options.route`      | `string` | Required. REST API endpoint path.                            |
+| `options.params` | `object` | URL query parameters for the given route. |
+| `options.method` | `string` | HTTP method for the given route. |
+| `options.headers` | `object` | Additional HTTP headers for the given route. |
+| `options.data` | `object | FormData` | Request body. |
+| `options.signal` | `AbortSignal`  | Optional `AbortSignal`. |
 
 The `replicate.request()` method is used by the other methods
 to interact with the Replicate API.
 You can call this method directly to make other requests to the API.
+
+The method accepts an `AbortSignal` which can be used to cancel the request in flight.
 
 ### `FileOutput`
 

--- a/README.md
+++ b/README.md
@@ -1219,7 +1219,7 @@ const response = await replicate.request(route, parameters);
 | `options.params`     | `object`            | URL query parameters for the given route. |
 | `options.method`     | `string`            | HTTP method for the given route. |
 | `options.headers`    | `object`            | Additional HTTP headers for the given route. |
-| `options.data`       | `object | FormData` | Request body. |
+| `options.data`       | `object \| FormData` | Request body. |
 | `options.signal`     | `AbortSignal`       | Optional `AbortSignal`. |
 
 The `replicate.request()` method is used by the other methods

--- a/README.md
+++ b/README.md
@@ -1213,14 +1213,14 @@ Low-level method used by the Replicate client to interact with API endpoints.
 const response = await replicate.request(route, parameters);
 ```
 
-| name                 | type   | description                                                  |
-| -------------------- | ------ | ------------------------------------------------------------ |
-| `options.route`      | `string` | Required. REST API endpoint path.                            |
-| `options.params` | `object` | URL query parameters for the given route. |
-| `options.method` | `string` | HTTP method for the given route. |
-| `options.headers` | `object` | Additional HTTP headers for the given route. |
-| `options.data` | `object | FormData` | Request body. |
-| `options.signal` | `AbortSignal`  | Optional `AbortSignal`. |
+| name                 | type                | description |
+| -------------------- | ------------------- | ----------- |
+| `options.route`      | `string`            | Required. REST API endpoint path.
+| `options.params`     | `object`            | URL query parameters for the given route. |
+| `options.method`     | `string`            | HTTP method for the given route. |
+| `options.headers`    | `object`            | Additional HTTP headers for the given route. |
+| `options.data`       | `object | FormData` | Request body. |
+| `options.signal`     | `AbortSignal`       | Optional `AbortSignal`. |
 
 The `replicate.request()` method is used by the other methods
 to interact with the Replicate API.

--- a/index.d.ts
+++ b/index.d.ts
@@ -201,12 +201,15 @@ declare module "replicate" {
     ): Promise<Prediction>;
 
     accounts: {
-      current(): Promise<Account>;
+      current(options?: { signal?: AbortSignal }): Promise<Account>;
     };
 
     collections: {
-      list(): Promise<Page<Collection>>;
-      get(collection_slug: string): Promise<Collection>;
+      list(options?: { signal?: AbortSignal }): Promise<Page<Collection>>;
+      get(
+        collection_slug: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Collection>;
     };
 
     deployments: {
@@ -221,21 +224,26 @@ declare module "replicate" {
             webhook?: string;
             webhook_events_filter?: WebhookEventType[];
             wait?: number | boolean;
+            signal?: AbortSignal;
           }
         ): Promise<Prediction>;
       };
       get(
         deployment_owner: string,
-        deployment_name: string
+        deployment_name: string,
+        options?: { signal?: AbortSignal }
       ): Promise<Deployment>;
-      create(deployment_config: {
-        name: string;
-        model: string;
-        version: string;
-        hardware: string;
-        min_instances: number;
-        max_instances: number;
-      }): Promise<Deployment>;
+      create(
+        deployment_config: {
+          name: string;
+          model: string;
+          version: string;
+          hardware: string;
+          min_instances: number;
+          max_instances: number;
+        },
+        options?: { signal?: AbortSignal }
+      ): Promise<Deployment>;
       update(
         deployment_owner: string,
         deployment_name: string,
@@ -249,32 +257,45 @@ declare module "replicate" {
           | { hardware: string }
           | { min_instances: number }
           | { max_instances: number }
-        )
+        ),
+        options?: { signal?: AbortSignal }
       ): Promise<Deployment>;
       delete(
         deployment_owner: string,
-        deployment_name: string
+        deployment_name: string,
+        options?: { signal?: AbortSignal }
       ): Promise<boolean>;
-      list(): Promise<Page<Deployment>>;
+      list(options?: { signal?: AbortSignal }): Promise<Page<Deployment>>;
     };
 
     files: {
       create(
         file: Blob | Buffer,
-        metadata?: Record<string, unknown>
+        metadata?: Record<string, unknown>,
+        options?: { signal?: AbortSignal }
       ): Promise<FileObject>;
-      list(): Promise<Page<FileObject>>;
-      get(file_id: string): Promise<FileObject>;
-      delete(file_id: string): Promise<boolean>;
+      list(options?: { signal?: AbortSignal }): Promise<Page<FileObject>>;
+      get(
+        file_id: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<FileObject>;
+      delete(
+        file_id: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<boolean>;
     };
 
     hardware: {
-      list(): Promise<Hardware[]>;
+      list(options?: { signal?: AbortSignal }): Promise<Hardware[]>;
     };
 
     models: {
-      get(model_owner: string, model_name: string): Promise<Model>;
-      list(): Promise<Page<Model>>;
+      get(
+        model_owner: string,
+        model_name: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Model>;
+      list(options?: { signal?: AbortSignal }): Promise<Page<Model>>;
       create(
         model_owner: string,
         model_name: string,
@@ -286,17 +307,26 @@ declare module "replicate" {
           paper_url?: string;
           license_url?: string;
           cover_image_url?: string;
+          signal?: AbortSignal;
         }
       ): Promise<Model>;
       versions: {
-        list(model_owner: string, model_name: string): Promise<ModelVersion[]>;
+        list(
+          model_owner: string,
+          model_name: string,
+          options?: { signal?: AbortSignal }
+        ): Promise<ModelVersion[]>;
         get(
           model_owner: string,
           model_name: string,
-          version_id: string
+          version_id: string,
+          options?: { signal?: AbortSignal }
         ): Promise<ModelVersion>;
       };
-      search(query: string): Promise<Page<Model>>;
+      search(
+        query: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Page<Model>>;
     };
 
     predictions: {
@@ -310,11 +340,18 @@ declare module "replicate" {
           webhook?: string;
           webhook_events_filter?: WebhookEventType[];
           wait?: boolean | number;
+          signal?: AbortSignal;
         } & ({ version: string } | { model: string })
       ): Promise<Prediction>;
-      get(prediction_id: string): Promise<Prediction>;
-      cancel(prediction_id: string): Promise<Prediction>;
-      list(): Promise<Page<Prediction>>;
+      get(
+        prediction_id: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Prediction>;
+      cancel(
+        prediction_id: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Prediction>;
+      list(options?: { signal?: AbortSignal }): Promise<Page<Prediction>>;
     };
 
     trainings: {
@@ -327,17 +364,24 @@ declare module "replicate" {
           input: object;
           webhook?: string;
           webhook_events_filter?: WebhookEventType[];
+          signal?: AbortSignal;
         }
       ): Promise<Training>;
-      get(training_id: string): Promise<Training>;
-      cancel(training_id: string): Promise<Training>;
-      list(): Promise<Page<Training>>;
+      get(
+        training_id: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Training>;
+      cancel(
+        training_id: string,
+        options?: { signal?: AbortSignal }
+      ): Promise<Training>;
+      list(options?: { signal?: AbortSignal }): Promise<Page<Training>>;
     };
 
     webhooks: {
       default: {
         secret: {
-          get(): Promise<WebhookSecret>;
+          get(options?: { signal?: AbortSignal }): Promise<WebhookSecret>;
         };
       };
     };

--- a/index.d.ts
+++ b/index.d.ts
@@ -183,6 +183,7 @@ declare module "replicate" {
         headers?: object | Headers;
         params?: object;
         data?: object;
+        signal?: AbortSignal;
       }
     ): Promise<Response>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -187,7 +187,10 @@ declare module "replicate" {
       }
     ): Promise<Response>;
 
-    paginate<T>(endpoint: () => Promise<Page<T>>): AsyncGenerator<[T]>;
+    paginate<T>(
+      endpoint: () => Promise<Page<T>>,
+      options?: { signal?: AbortSignal }
+    ): AsyncGenerator<T[]>;
 
     wait(
       prediction: Prediction,

--- a/index.js
+++ b/index.js
@@ -356,15 +356,20 @@ class Replicate {
    *    console.log(page);
    * }
    * @param {Function} endpoint - Function that returns a promise for the next page of results
+   * @param {object} [options]
+   * @param {AbortSignal} [options.signal] - AbortSignal to cancel the request.
    * @yields {object[]} Each page of results
    */
-  async *paginate(endpoint) {
+  async *paginate(endpoint, options = {}) {
     const response = await endpoint();
     yield response.results;
-    if (response.next) {
+    if (response.next && !(options.signal && options.signal.aborted)) {
       const nextPage = () =>
-        this.request(response.next, { method: "GET" }).then((r) => r.json());
-      yield* this.paginate(nextPage);
+        this.request(response.next, {
+          method: "GET",
+          signal: options.signal,
+        }).then((r) => r.json());
+      yield* this.paginate(nextPage, options);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -225,6 +225,7 @@ class Replicate {
    * @param {object} [options.params] - Query parameters
    * @param {object|Headers} [options.headers] - HTTP headers
    * @param {object} [options.data] - Body parameters
+   * @param {AbortSignal} [options.signal] - AbortSignal to cancel the request
    * @returns {Promise<Response>} - Resolves with the response object
    * @throws {ApiError} If the request failed
    */
@@ -241,7 +242,7 @@ class Replicate {
       );
     }
 
-    const { method = "GET", params = {}, data } = options;
+    const { method = "GET", params = {}, data, signal } = options;
 
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.append(key, value);
@@ -273,6 +274,7 @@ class Replicate {
       method,
       headers,
       body,
+      signal,
     };
 
     const shouldRetry =

--- a/integration/next/pages/index.js
+++ b/integration/next/pages/index.js
@@ -1,5 +1,5 @@
 export default () => (
-	<main>
-		<h1>Welcome to Next.js</h1>
-	</main>
-)
+  <main>
+    <h1>Welcome to Next.js</h1>
+  </main>
+);

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -1,11 +1,14 @@
 /**
  * Get the current account
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the current account
  */
-async function getCurrentAccount() {
+async function getCurrentAccount({ signal } = {}) {
   const response = await this.request("/account", {
     method: "GET",
+    signal,
   });
 
   return response.json();

--- a/lib/collections.js
+++ b/lib/collections.js
@@ -2,11 +2,14 @@
  * Fetch a model collection
  *
  * @param {string} collection_slug - Required. The slug of the collection. See http://replicate.com/collections
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with the collection data
  */
-async function getCollection(collection_slug) {
+async function getCollection(collection_slug, { signal } = {}) {
   const response = await this.request(`/collections/${collection_slug}`, {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -15,11 +18,14 @@ async function getCollection(collection_slug) {
 /**
  * Fetch a list of model collections
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with the collections data
  */
-async function listCollections() {
+async function listCollections({ signal } = {}) {
   const response = await this.request("/collections", {
     method: "GET",
+    signal,
   });
 
   return response.json();

--- a/lib/deployments.js
+++ b/lib/deployments.js
@@ -10,10 +10,11 @@ const { transformFileInputs } = require("./util");
  * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
  * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
  * @param {boolean|integer} [options.wait] - Whether to wait until the prediction is completed before returning. If an integer is provided, it will wait for that many seconds. Defaults to false
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the created prediction data
  */
 async function createPrediction(deployment_owner, deployment_name, options) {
-  const { input, wait, ...data } = options;
+  const { input, wait, signal, ...data } = options;
 
   if (data.webhook) {
     try {
@@ -47,6 +48,7 @@ async function createPrediction(deployment_owner, deployment_name, options) {
           this.fileEncodingStrategy
         ),
       },
+      signal,
     }
   );
 
@@ -58,13 +60,20 @@ async function createPrediction(deployment_owner, deployment_name, options) {
  *
  * @param {string} deployment_owner - Required. The username of the user or organization who owns the deployment
  * @param {string} deployment_name - Required. The name of the deployment
+ * @param {object] [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the deployment data
  */
-async function getDeployment(deployment_owner, deployment_name) {
+async function getDeployment(
+  deployment_owner,
+  deployment_name,
+  { signal } = {}
+) {
   const response = await this.request(
     `/deployments/${deployment_owner}/${deployment_name}`,
     {
       method: "GET",
+      signal,
     }
   );
 
@@ -84,13 +93,16 @@ async function getDeployment(deployment_owner, deployment_name) {
 /**
  * Create a deployment
  *
- * @param {DeploymentCreateRequest} config - Required. The deployment config.
+ * @param {DeploymentCreateRequest} deployment_config - Required. The deployment config.
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the deployment data
  */
-async function createDeployment(deployment_config) {
+async function createDeployment(deployment_config, { signal } = {}) {
   const response = await this.request("/deployments", {
     method: "POST",
     data: deployment_config,
+    signal,
   });
 
   return response.json();
@@ -110,18 +122,22 @@ async function createDeployment(deployment_config) {
  * @param {string} deployment_owner - Required. The username of the user or organization who owns the deployment
  * @param {string} deployment_name - Required. The name of the deployment
  * @param {DeploymentUpdateRequest} deployment_config - Required. The deployment changes.
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the deployment data
  */
 async function updateDeployment(
   deployment_owner,
   deployment_name,
-  deployment_config
+  deployment_config,
+  { signal } = {}
 ) {
   const response = await this.request(
     `/deployments/${deployment_owner}/${deployment_name}`,
     {
       method: "PATCH",
       data: deployment_config,
+      signal,
     }
   );
 
@@ -133,13 +149,20 @@ async function updateDeployment(
  *
  * @param {string} deployment_owner - Required. The username of the user or organization who owns the deployment
  * @param {string} deployment_name - Required. The name of the deployment
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<boolean>} Resolves with true if the deployment was deleted
  */
-async function deleteDeployment(deployment_owner, deployment_name) {
+async function deleteDeployment(
+  deployment_owner,
+  deployment_name,
+  { signal } = {}
+) {
   const response = await this.request(
     `/deployments/${deployment_owner}/${deployment_name}`,
     {
       method: "DELETE",
+      signal,
     }
   );
 
@@ -149,11 +172,14 @@ async function deleteDeployment(deployment_owner, deployment_name) {
 /**
  * List all deployments
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with a page of deployments
  */
-async function listDeployments() {
+async function listDeployments({ signal } = {}) {
   const response = await this.request("/deployments", {
     method: "GET",
+    signal,
   });
 
   return response.json();

--- a/lib/files.js
+++ b/lib/files.js
@@ -3,9 +3,11 @@
  *
  * @param {object} file - Required. The file object.
  * @param {object} metadata - Optional. User-provided metadata associated with the file.
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with the file data
  */
-async function createFile(file, metadata = {}) {
+async function createFile(file, metadata = {}, { signal } = {}) {
   const form = new FormData();
 
   let filename;
@@ -36,6 +38,7 @@ async function createFile(file, metadata = {}) {
     headers: {
       "Content-Type": "multipart/form-data",
     },
+    signal,
   });
 
   return response.json();
@@ -44,11 +47,14 @@ async function createFile(file, metadata = {}) {
 /**
  * List all files
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with the files data
  */
-async function listFiles() {
+async function listFiles({ signal } = {}) {
   const response = await this.request("/files", {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -58,11 +64,14 @@ async function listFiles() {
  * Get a file
  *
  * @param {string} file_id - Required. The ID of the file.
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with the file data
  */
-async function getFile(file_id) {
+async function getFile(file_id, { signal } = {}) {
   const response = await this.request(`/files/${file_id}`, {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -72,11 +81,14 @@ async function getFile(file_id) {
  * Delete a file
  *
  * @param {string} file_id - Required. The ID of the file.
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<boolean>} - Resolves with true if the file was deleted
  */
-async function deleteFile(file_id) {
+async function deleteFile(file_id, { signal } = {}) {
   const response = await this.request(`/files/${file_id}`, {
     method: "DELETE",
+    signal,
   });
 
   return response.status === 204;

--- a/lib/hardware.js
+++ b/lib/hardware.js
@@ -1,11 +1,14 @@
 /**
  * List hardware
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object[]>} Resolves with the array of hardware
  */
-async function listHardware() {
+async function listHardware({ signal } = {}) {
   const response = await this.request("/hardware", {
     method: "GET",
+    signal,
   });
 
   return response.json();

--- a/lib/models.js
+++ b/lib/models.js
@@ -3,11 +3,14 @@
  *
  * @param {string} model_owner - Required. The name of the user or organization that owns the model
  * @param {string} model_name - Required. The name of the model
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the model data
  */
-async function getModel(model_owner, model_name) {
+async function getModel(model_owner, model_name, { signal } = {}) {
   const response = await this.request(`/models/${model_owner}/${model_name}`, {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -18,13 +21,16 @@ async function getModel(model_owner, model_name) {
  *
  * @param {string} model_owner - Required. The name of the user or organization that owns the model
  * @param {string} model_name - Required. The name of the model
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the list of model versions
  */
-async function listModelVersions(model_owner, model_name) {
+async function listModelVersions(model_owner, model_name, { signal } = {}) {
   const response = await this.request(
     `/models/${model_owner}/${model_name}/versions`,
     {
       method: "GET",
+      signal,
     }
   );
 
@@ -37,13 +43,21 @@ async function listModelVersions(model_owner, model_name) {
  * @param {string} model_owner - Required. The name of the user or organization that owns the model
  * @param {string} model_name - Required. The name of the model
  * @param {string} version_id - Required. The model version
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the model version data
  */
-async function getModelVersion(model_owner, model_name, version_id) {
+async function getModelVersion(
+  model_owner,
+  model_name,
+  version_id,
+  { signal } = {}
+) {
   const response = await this.request(
     `/models/${model_owner}/${model_name}/versions/${version_id}`,
     {
       method: "GET",
+      signal,
     }
   );
 
@@ -53,11 +67,14 @@ async function getModelVersion(model_owner, model_name, version_id) {
 /**
  * List all public models
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the model version data
  */
-async function listModels() {
+async function listModels({ signal } = {}) {
   const response = await this.request("/models", {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -76,14 +93,17 @@ async function listModels() {
  * @param {string} options.paper_url - A URL for the model's paper.
  * @param {string} options.license_url - A URL for the model's license.
  * @param {string} options.cover_image_url - A URL for the model's cover image. This should be an image file.
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the model version data
  */
 async function createModel(model_owner, model_name, options) {
-  const data = { owner: model_owner, name: model_name, ...options };
+  const { signal, ...rest } = options;
+  const data = { owner: model_owner, name: model_name, ...rest };
 
   const response = await this.request("/models", {
     method: "POST",
     data,
+    signal,
   });
 
   return response.json();
@@ -93,15 +113,18 @@ async function createModel(model_owner, model_name, options) {
  * Search for public models
  *
  * @param {string} query - The search query
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with a page of models matching the search query
  */
-async function search(query) {
+async function search(query, { signal } = {}) {
   const response = await this.request("/models", {
     method: "QUERY",
     headers: {
       "Content-Type": "text/plain",
     },
     data: query,
+    signal,
   });
 
   return response.json();

--- a/lib/predictions.js
+++ b/lib/predictions.js
@@ -10,10 +10,11 @@ const { transformFileInputs } = require("./util");
  * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the prediction has new output
  * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
  * @param {boolean|integer} [options.wait] - Whether to wait until the prediction is completed before returning. If an integer is provided, it will wait for that many seconds. Defaults to false
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the created prediction
  */
 async function createPrediction(options) {
-  const { model, version, input, wait, ...data } = options;
+  const { model, version, input, wait, signal, ...data } = options;
 
   if (data.webhook) {
     try {
@@ -48,6 +49,7 @@ async function createPrediction(options) {
         ),
         version,
       },
+      signal,
     });
   } else if (model) {
     response = await this.request(`/models/${model}/predictions`, {
@@ -61,6 +63,7 @@ async function createPrediction(options) {
           this.fileEncodingStrategy
         ),
       },
+      signal,
     });
   } else {
     throw new Error("Either model or version must be specified");
@@ -73,11 +76,14 @@ async function createPrediction(options) {
  * Fetch a prediction by ID
  *
  * @param {number} prediction_id - Required. The prediction ID
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the prediction data
  */
-async function getPrediction(prediction_id) {
+async function getPrediction(prediction_id, { signal } = {}) {
   const response = await this.request(`/predictions/${prediction_id}`, {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -87,11 +93,14 @@ async function getPrediction(prediction_id) {
  * Cancel a prediction by ID
  *
  * @param {string} prediction_id - Required. The training ID
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the data for the training
  */
-async function cancelPrediction(prediction_id) {
+async function cancelPrediction(prediction_id, { signal } = {}) {
   const response = await this.request(`/predictions/${prediction_id}/cancel`, {
     method: "POST",
+    signal,
   });
 
   return response.json();
@@ -100,11 +109,14 @@ async function cancelPrediction(prediction_id) {
 /**
  * List all predictions
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with a page of predictions
  */
-async function listPredictions() {
+async function listPredictions({ signal } = {}) {
   const response = await this.request("/predictions", {
     method: "GET",
+    signal,
   });
 
   return response.json();

--- a/lib/trainings.js
+++ b/lib/trainings.js
@@ -9,10 +9,11 @@
  * @param {object} options.input - Required. An object with the model inputs
  * @param {string} [options.webhook] - An HTTPS URL for receiving a webhook when the training updates
  * @param {string[]} [options.webhook_events_filter] - You can change which events trigger webhook requests by specifying webhook events (`start`|`output`|`logs`|`completed`)
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the data for the created training
  */
 async function createTraining(model_owner, model_name, version_id, options) {
-  const { ...data } = options;
+  const { signal, ...data } = options;
 
   if (data.webhook) {
     try {
@@ -28,6 +29,7 @@ async function createTraining(model_owner, model_name, version_id, options) {
     {
       method: "POST",
       data,
+      signal,
     }
   );
 
@@ -38,11 +40,14 @@ async function createTraining(model_owner, model_name, version_id, options) {
  * Fetch a training by ID
  *
  * @param {string} training_id - Required. The training ID
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the data for the training
  */
-async function getTraining(training_id) {
+async function getTraining(training_id, { signal } = {}) {
   const response = await this.request(`/trainings/${training_id}`, {
     method: "GET",
+    signal,
   });
 
   return response.json();
@@ -52,11 +57,14 @@ async function getTraining(training_id) {
  * Cancel a training by ID
  *
  * @param {string} training_id - Required. The training ID
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the data for the training
  */
-async function cancelTraining(training_id) {
+async function cancelTraining(training_id, { signal } = {}) {
   const response = await this.request(`/trainings/${training_id}/cancel`, {
     method: "POST",
+    signal,
   });
 
   return response.json();
@@ -65,11 +73,14 @@ async function cancelTraining(training_id) {
 /**
  * List all trainings
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} - Resolves with a page of trainings
  */
-async function listTrainings() {
+async function listTrainings({ signal } = {}) {
   const response = await this.request("/trainings", {
     method: "GET",
+    signal,
   });
 
   return response.json();

--- a/lib/util.js
+++ b/lib/util.js
@@ -247,7 +247,7 @@ async function withAutomaticRetries(request, options = {}) {
  * @param {Replicate} client - The client used to upload the file
  * @param {object} inputs - The inputs to transform
  * @param {"default" | "upload" | "data-uri"} strategy - Whether to upload files to Replicate, encode as dataURIs or try both.
- * @returns {object} - The transformed inputs
+ * @returns {Promise<object>} - The transformed inputs
  * @throws {ApiError} If the request to upload the file fails
  */
 async function transformFileInputs(client, inputs, strategy) {
@@ -280,7 +280,7 @@ async function transformFileInputs(client, inputs, strategy) {
  *
  * @param {Replicate} client - The client used to upload the file
  * @param {object} inputs - The inputs to transform
- * @returns {object} - The transformed inputs
+ * @returns {Promise<object>} - The transformed inputs
  * @throws {ApiError} If the request to upload the file fails
  */
 async function transformFileInputsToReplicateFileURLs(client, inputs) {
@@ -301,8 +301,8 @@ const MAX_DATA_URI_SIZE = 10_000_000;
  * base64-encoded data URI.
  *
  * @param {object} inputs - The inputs to transform
- * @returns {object} - The transformed inputs
- * @throws {Error} If the size of inputs exceeds a given threshould set by MAX_DATA_URI_SIZE
+ * @returns {Promise<object>} - The transformed inputs
+ * @throws {Error} If the size of inputs exceeds a given threshold set by MAX_DATA_URI_SIZE
  */
 async function transformFileInputsToBase64EncodedDataURIs(inputs) {
   let totalBytes = 0;
@@ -311,10 +311,10 @@ async function transformFileInputsToBase64EncodedDataURIs(inputs) {
     let mime;
 
     if (value instanceof Blob) {
-      // Currently we use a NodeJS only API for base64 encoding, as
+      // Currently, we use a NodeJS only API for base64 encoding, as
       // we move to support the browser we could support either using
       // btoa (which does string encoding), the FileReader API or
-      // a JavaScript implenentation like base64-js.
+      // a JavaScript implementation like base64-js.
       // See: https://developer.mozilla.org/en-US/docs/Glossary/Base64
       // See: https://github.com/beatgammit/base64-js
       buffer = await value.arrayBuffer();

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,11 +1,14 @@
 /**
  * Get the default webhook signing secret
  *
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - An optional AbortSignal
  * @returns {Promise<object>} Resolves with the signing secret for the default webhook
  */
-async function getDefaultWebhookSecret() {
+async function getDefaultWebhookSecret({ signal } = {}) {
   const response = await this.request("/webhooks/default/secret", {
     method: "GET",
+    signal,
   });
 
   return response.json();


### PR DESCRIPTION
This PR adds support for passing `AbortSignal` to all API methods that make HTTP requests, these are passed directly into the native `fetch()` implementation, so it's up to the user to handle the `AbortError` raised, if any.

```js
const controller = new AbortController();
try {
  const prediction = await replicate.predictions.create({
    version: 'xyz',
    ...,
    signal: controller.signal,
  });
} catch (err) {
  if (err instanceof DOMException && err.name === "AbortError") {
    ...
  }
}
```

The `paginate` function also checks to see whether the signal was aborted before proceeding to the next iteration. If so it returns immediately to avoid making a redundant fetch call.

This allows the client to take advantage of various frameworks that provide an `AbortSignal` instance to tear down any in flight requests.
