### PR TITLE
Remove attempt to require "node:crypto" on Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ const requestData = {
 const webhookIsValid = await validateWebhook(requestData);
 ```
 
+> [!NOTE]
+> The `validateWebhook` function uses the global `crypto` API available in most JavaScript runtimes. Node <= 18 does not provide this global so in this case you need to either call node with the `--no-experimental-global-webcrypto` or provide the `webcrypto` module manually.
+> ```js
+> const crypto = require("node:crypto").webcrypto;
+> const webhookIsValid = await valdiateWebhook(requestData, crypto);
+> ```
+
 ## TypeScript
 
 The `Replicate` constructor and all `replicate.*` methods are fully typed.

--- a/index.d.ts
+++ b/index.d.ts
@@ -340,16 +340,20 @@ declare module "replicate" {
   }
 
   export function validateWebhook(
-    requestData:
-      | Request
-      | {
-          id?: string;
-          timestamp?: string;
-          body: string;
-          secret?: string;
-          signature?: string;
-        },
-    secret: string
+    request: Request,
+    secret: string,
+    crypto?: Crypto
+  ): Promise<boolean>;
+
+  export function validateWebhook(
+    requestData: {
+      id: string;
+      timestamp: string;
+      signature: string;
+      body: string;
+      secret: string;
+    },
+    crypto?: Crypto
   ): Promise<boolean>;
 
   export function parseProgressFromLogs(logs: Prediction | string): {

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,6 +10,7 @@ const { create: createFile } = require("./files");
  * @param {string} requestData.body - The raw body of the incoming webhook request.
  * @param {string} requestData.secret - The webhook secret, obtained from `replicate.webhooks.defaul.secret` method.
  * @param {string} requestData.signature - The webhook signature header from the incoming request, comprising one or more space-delimited signatures.
+ * @param {Crypto} [crypto] - An optional `Crypto` implementation that conforms to the [browser Crypto interface](https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto)
  */
 
 /**
@@ -22,6 +23,7 @@ const { create: createFile } = require("./files");
  * @param {string} requestData.headers["webhook-signature"] - The webhook signature header from the incoming request, comprising one or more space-delimited signatures
  * @param {string} requestData.body - The raw body of the incoming webhook request
  * @param {string} secret - The webhook secret, obtained from `replicate.webhooks.defaul.secret` method
+ * @param {Crypto} [crypto] - An optional `Crypto` implementation that conforms to the [browser Crypto interface](https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto)
  */
 
 /**
@@ -30,9 +32,13 @@ const { create: createFile } = require("./files");
  * @returns {Promise<boolean>} - True if the signature is valid
  * @throws {Error} - If the request is missing required headers, body, or secret
  */
-async function validateWebhook(requestData, secret) {
-  let { id, timestamp, body, signature } = requestData;
-  const signingSecret = secret || requestData.secret;
+async function validateWebhook(requestData, secretOrCrypto, customCrypto) {
+  let id;
+  let body;
+  let timestamp;
+  let signature;
+  let secret;
+  let crypto = globalThis.crypto;
 
   if (requestData && requestData.headers && requestData.body) {
     if (typeof requestData.headers.get === "function") {
@@ -47,6 +53,19 @@ async function validateWebhook(requestData, secret) {
       signature = requestData.headers["webhook-signature"];
     }
     body = requestData.body;
+    secret = secretOrCrypto;
+    if (customCrypto) {
+      crypto = customCrypto;
+    }
+  } else {
+    id = requestData.id;
+    body = requestData.body;
+    timestamp = requestData.timestamp;
+    signature = requestData.signature;
+    secret = requestData.secret;
+    if (secretOrCrypto) {
+      crypto = secretOrCrypto;
+    }
   }
 
   if (body instanceof ReadableStream || body.readable) {
@@ -71,15 +90,22 @@ async function validateWebhook(requestData, secret) {
     throw new Error("Missing required body");
   }
 
-  if (!signingSecret) {
+  if (!secret) {
     throw new Error("Missing required secret");
+  }
+
+  if (!crypto) {
+    throw new Error(
+      'Missing `crypto` implementation. If using Node 18 pass in require("node:crypto").webcrypto'
+    );
   }
 
   const signedContent = `${id}.${timestamp}.${body}`;
 
   const computedSignature = await createHMACSHA256(
-    signingSecret.split("_").pop(),
-    signedContent
+    secret.split("_").pop(),
+    signedContent,
+    crypto
   );
 
   const expectedSignatures = signature
@@ -94,8 +120,9 @@ async function validateWebhook(requestData, secret) {
 /**
  * @param {string} secret - base64 encoded string
  * @param {string} data - text body of request
+ * @param {Crypto} crypto - an implementation of the web Crypto api
  */
-async function createHMACSHA256(secret, data) {
+async function createHMACSHA256(secret, data, crypto) {
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     "raw",

--- a/lib/util.js
+++ b/lib/util.js
@@ -97,24 +97,6 @@ async function validateWebhook(requestData, secret) {
  */
 async function createHMACSHA256(secret, data) {
   const encoder = new TextEncoder();
-  let crypto = globalThis.crypto;
-
-  // In Node 18 the `crypto` global is behind a --no-experimental-global-webcrypto flag
-  if (typeof crypto === "undefined" && typeof require === "function") {
-    // NOTE: Webpack (primarily as it's used by Next.js) and perhaps some
-    // other bundlers do not currently support the `node` protocol and will
-    // error if it's found in the source. Other platforms like CloudFlare
-    // will only support requires when using the node protocol.
-    //
-    // As this line is purely to support Node 18.x we make an indirect request
-    // to the require function which fools Webpack...
-    //
-    // We may be able to remove this in future as it looks like Webpack is getting
-    // support for requiring using the `node:` protocol.
-    // See: https://github.com/webpack/webpack/issues/18277
-    crypto = require.call(null, "node:crypto").webcrypto;
-  }
-
   const key = await crypto.subtle.importKey(
     "raw",
     base64ToBytes(secret),

--- a/lib/util.js
+++ b/lib/util.js
@@ -53,6 +53,12 @@ async function validateWebhook(requestData, secretOrCrypto, customCrypto) {
       signature = requestData.headers["webhook-signature"];
     }
     body = requestData.body;
+    if (typeof secretOrCrypto !== "string") {
+      throw new Error(
+        "Unexpected value for secret passed to validateWebhook, expected a string"
+      );
+    }
+
     secret = secretOrCrypto;
     if (customCrypto) {
       crypto = customCrypto;


### PR DESCRIPTION
Fixes #273 & #345

The original code was intended to shim in support for the webcrypto interface in Node 18, which was included indirectly as `webcrypto` in the "node:crypto" module or globally via the `--no-experimental-global-webcrypto` flag.

This change has caused many issues with bundlers and static analyzers which do not like the obfuscated call to `require()` see the above tickets.

Node 18 will no longer receive security support as of 30 April 2025[1] and as such it feels like we can now drop this workaround in favor of documenting the alternative approaches.

The test suite has also been updated to use `webcrypto` on Node 18.

[1]: https://endoflife.date/nodejs