### PR TITLE
Update interface for replicate.models.versions.list()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -315,7 +315,7 @@ declare module "replicate" {
           model_owner: string,
           model_name: string,
           options?: { signal?: AbortSignal }
-        ): Promise<ModelVersion[]>;
+        ): Promise<Page<ModelVersion>>;
         get(
           model_owner: string,
           model_name: string,


### PR DESCRIPTION
The endpoint returns a paginated list rather than an array