### PR TITLE
feat: expose is_official boolean on models

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,7 @@ declare module "replicate" {
     name: string;
     description?: string;
     visibility: "public" | "private";
+    is_official: boolean;
     github_url?: string;
     paper_url?: string;
     license_url?: string;


### PR DESCRIPTION
Our API now returns an `is_official` boolean field for models.