### PR TITLE
feat(collection): add typescript info for full_description field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ declare module "replicate" {
     name: string;
     slug: string;
     description: string;
+    full_description: string | null;
     models?: Model[];
   }
 


### PR DESCRIPTION
The API now returns a `full_description` field for collections which contains a markdown string.