### PR TITLE
1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "replicate",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "replicate",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replicate",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "JavaScript client for Replicate",
   "repository": "github:replicate/replicate-javascript",
   "homepage": "https://github.com/replicate/replicate-javascript#readme",


### PR DESCRIPTION
We can't push directly to `main` anymore, and it looks like the actual publishing step succeeded when I ran `npx np minor`. https://www.npmjs.com/package/replicate/v/1.3.0

This change gets the `package.json` version reconciled with the latest published version.